### PR TITLE
Playwright see/grabNumberOfVisibleElements do not filter out elements ...

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1050,7 +1050,7 @@ class Playwright extends Helper {
    */
   async seeElement(locator) {
     let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.boundingBox()));
+    els = await Promise.all(els.map(el => el.isVisible()));
     return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
   }
 
@@ -1060,7 +1060,7 @@ class Playwright extends Helper {
    */
   async dontSeeElement(locator) {
     let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.boundingBox()));
+    els = await Promise.all(els.map(el => el.isVisible()));
     return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
   }
 
@@ -1364,7 +1364,7 @@ class Playwright extends Helper {
    */
   async grabNumberOfVisibleElements(locator) {
     let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.boundingBox()));
+    els = await Promise.all(els.map(el => el.isVisible()));
     return els.filter(v => v).length;
   }
 

--- a/test/data/app/view/form/field.php
+++ b/test/data/app/view/form/field.php
@@ -6,5 +6,8 @@
     <input type="text" id="email" name="email" style="display:none;"/>
     <input type="submit" value="Submit" />
 </form>
+<form style="width: 100px; height: 40px; visibility:hidden; background: red" action="/form/simple" method="POST">
+    <input type="text" id="noid" name="noname" value="RANDOM_VALUE" />
+</form>
 </body>
 </html>

--- a/test/data/app/view/info.php
+++ b/test/data/app/view/info.php
@@ -57,5 +57,7 @@
    <span class="span" style="height:12px">Fisrt <span>
    <span class="span">Second <span>
 </div>
+<div class="issue2928" style="width: 100px; height: 40px; visibility:hidden; background: red">visibility:hidden</div>
+<div class="issue2928" style="width: 100px; height: 40px; background: green">no visibility hidden</div>
 </body>
 </html>

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -127,12 +127,16 @@ module.exports.tests = function () {
       await I.seeElement('//input[@id="name"]');
       await I.dontSeeElement('#something-beyond');
       await I.dontSeeElement('//input[@id="something-beyond"]');
+      await I.dontSeeElement({ name: 'noname' });
+      await I.dontSeeElement('#noid');
     });
 
     it('should check elements are in the DOM', async () => {
       await I.amOnPage('/form/field');
       await I.seeElementInDOM('input[name=name]');
       await I.seeElementInDOM('//input[@id="name"]');
+      await I.seeElementInDOM({ name: 'noname' });
+      await I.seeElementInDOM('#noid');
       await I.dontSeeElementInDOM('#something-beyond');
       await I.dontSeeElementInDOM('//input[@id="something-beyond"]');
     });
@@ -177,6 +181,12 @@ module.exports.tests = function () {
       await I.amOnPage('/info');
       const num = await I.grabNumberOfVisibleElements('button[type=submit]');
       assert.equal(num, 0);
+    });
+
+    it('should honor visibility hidden style', async () => {
+      await I.amOnPage('/info');
+      const num = await I.grabNumberOfVisibleElements('.issue2928');
+      assert.equal(num, 1);
     });
   });
 


### PR DESCRIPTION
… with visibility:hidden css #2928

- playwright helper and tests were updated to use isVisible palywright method and test visibility related functions on elements with visibility:hidden style

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
