### PR TITLE
[TEST] Update playwright helper type declaration to explicitly declare Promise return types

### DIFF
--- a/docs/helpers/ApiDataFactory.md
+++ b/docs/helpers/ApiDataFactory.md
@@ -250,6 +250,6 @@ I.haveMultiple('post', 3, { author: 'davert' });
 
 [2]: https://www.npmjs.com/package/faker
 
-[3]: https://codecept.io/helpers/REST/
+[3]: http://codecept.io/helpers/REST/
 
 [4]: https://github.com/axios/axios#request-config

--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -150,6 +150,8 @@ I.runOnAndroid((caps) => {
 -   `caps` **any** 
 -   `fn` **any** 
 
+Returns **[Promise][4]&lt;any>** 
+
 ### runOnAndroid
 
 Execute code only on Android
@@ -186,6 +188,8 @@ I.runOnAndroid((caps) => {
 -   `caps` **any** 
 -   `fn` **any** 
 
+Returns **[Promise][4]&lt;any>** 
+
 ### runInWeb
 
 Execute code only in Web mode.
@@ -201,6 +205,8 @@ I.runInWeb(() => {
 
 -   `fn` **any** 
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeAppIsInstalled
 
 Check if an app is installed.
@@ -211,7 +217,9 @@ I.seeAppIsInstalled("com.example.android.apis");
 
 #### Parameters
 
--   `bundleId` **[string][4]** String  ID of bundled appAppium: support only Android
+-   `bundleId` **[string][5]** String  ID of bundled app
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### seeAppIsNotInstalled
 
@@ -223,7 +231,9 @@ I.seeAppIsNotInstalled("com.example.android.apis");
 
 #### Parameters
 
--   `bundleId` **[string][4]** String  ID of bundled appAppium: support only Android
+-   `bundleId` **[string][5]** String  ID of bundled app
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### installApp
 
@@ -235,7 +245,9 @@ I.installApp('/path/to/file.apk');
 
 #### Parameters
 
--   `path` **[string][4]** path to apk fileAppium: support only Android
+-   `path` **[string][5]** path to apk file
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### removeApp
 
@@ -249,8 +261,8 @@ Appium: support only Android
 
 #### Parameters
 
--   `appId` **[string][4]** 
--   `bundleId` **[string][4]?** ID of bundle
+-   `appId` **[string][5]** 
+-   `bundleId` **[string][5]?** ID of bundle
 
 ### seeCurrentActivityIs
 
@@ -262,7 +274,9 @@ I.seeCurrentActivityIs(".HomeScreenActivity")
 
 #### Parameters
 
--   `currentActivity` **[string][4]** Appium: support only Android
+-   `currentActivity` **[string][5]** 
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### seeDeviceIsLocked
 
@@ -272,7 +286,7 @@ Check whether the device is locked.
 I.seeDeviceIsLocked();
 ```
 
-Appium: support only Android
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### seeDeviceIsUnlocked
 
@@ -282,7 +296,7 @@ Check whether the device is not locked.
 I.seeDeviceIsUnlocked();
 ```
 
-Appium: support only Android
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### seeOrientationIs
 
@@ -297,6 +311,8 @@ I.seeOrientationIs('LANDSCAPE')
 
 -   `orientation` **(`"LANDSCAPE"` \| `"PORTRAIT"`)** LANDSCAPE or PORTRAITAppium: support Android and iOS
 
+Returns **[Promise][4]&lt;void>** 
+
 ### setOrientation
 
 Set a device orientation. Will fail, if app will not set orientation
@@ -308,7 +324,9 @@ I.setOrientation('LANDSCAPE')
 
 #### Parameters
 
--   `orientation` **(`"LANDSCAPE"` \| `"PORTRAIT"`)** LANDSCAPE or PORTRAITAppium: support Android and iOS
+-   `orientation` **(`"LANDSCAPE"` \| `"PORTRAIT"`)** LANDSCAPE or PORTRAIT
+
+Returns **[Promise][4]&lt;any>** Appium: support Android and iOS
 
 ### grabAllContexts
 
@@ -316,7 +334,7 @@ Get list of all available contexts
 
     let contexts = await I.grabAllContexts();
 
-Appium: support Android and iOS
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** Appium: support Android and iOS
 
 ### grabContext
 
@@ -326,7 +344,7 @@ Retrieve current context
 let context = await I.grabContext();
 ```
 
-Appium: support Android and iOS
+Returns **[Promise][4]&lt;([string][5] | null)>** Appium: support Android and iOS
 
 ### grabCurrentActivity
 
@@ -336,7 +354,7 @@ Get current device activity.
 let activity = await I.grabCurrentActivity();
 ```
 
-Appium: support only Android
+Returns **[Promise][4]&lt;[string][5]>** Appium: support only Android
 
 ### grabNetworkConnection
 
@@ -348,7 +366,7 @@ properties to the response object to allow easier assertions.
 let con = await I.grabNetworkConnection();
 ```
 
-Appium: support only Android
+Returns **[Promise][4]&lt;{}>** Appium: support only Android
 
 ### grabOrientation
 
@@ -358,7 +376,7 @@ Get current orientation.
 let orientation = await I.grabOrientation();
 ```
 
-Appium: support Android and iOS
+Returns **[Promise][4]&lt;[string][5]>** Appium: support Android and iOS
 
 ### grabSettings
 
@@ -368,7 +386,7 @@ Get all the currently specified settings.
 let settings = await I.grabSettings();
 ```
 
-Appium: support Android and iOS
+Returns **[Promise][4]&lt;[string][5]>** Appium: support Android and iOS
 
 ### \_switchToContext
 
@@ -393,7 +411,9 @@ I.switchToWeb('WEBVIEW_io.selendroid.testapp');
 
 #### Parameters
 
--   `context` **[string][4]?** 
+-   `context` **[string][5]?** 
+
+Returns **[Promise][4]&lt;void>** 
 
 ### switchToNative
 
@@ -411,6 +431,8 @@ I.switchToNative('SOME_OTHER_CONTEXT');
 
 -   `context` **any**  (optional, default `null`)
 
+Returns **[Promise][4]&lt;void>** 
+
 ### startActivity
 
 Start an arbitrary Android activity during a session.
@@ -419,12 +441,12 @@ Start an arbitrary Android activity during a session.
 I.startActivity('io.selendroid.testapp', '.RegisterUserActivity');
 ```
 
-Appium: support only Android
-
 #### Parameters
 
 -   `appPackage`  
 -   `appActivity`  
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### setNetworkConnection
 
@@ -442,13 +464,13 @@ I.setNetworkConnection(4) // airplane mode off, wifi off, data on
 I.setNetworkConnection(6) // airplane mode off, wifi on, data on
 ```
 
-See corresponding [webdriverio reference][5].
-
-Appium: support only Android
+See corresponding [webdriverio reference][7].
 
 #### Parameters
 
 -   `value`  
+
+Returns **[Promise][4]&lt;{}>** Appium: support only Android
 
 ### setSettings
 
@@ -460,7 +482,9 @@ I.setSettings({cyberdelia: 'open'});
 
 #### Parameters
 
--   `settings` **[object][6]** objectAppium: support Android and iOS
+-   `settings` **[object][8]** object
+
+Returns **[Promise][4]&lt;any>** Appium: support Android and iOS
 
 ### hideDeviceKeyboard
 
@@ -480,12 +504,12 @@ Appium: support Android and iOS
 #### Parameters
 
 -   `strategy` **(`"tapOutside"` \| `"pressKey"`)?** Desired strategy to close keyboard (‘tapOutside’ or ‘pressKey’)
--   `key` **[string][4]?** Optional key
+-   `key` **[string][5]?** Optional key
 
 ### sendDeviceKeyEvent
 
 Send a key event to the device.
-List of keys: [https://developer.android.com/reference/android/view/KeyEvent.html][7]
+List of keys: [https://developer.android.com/reference/android/view/KeyEvent.html][9]
 
 ```js
 I.sendDeviceKeyEvent(3);
@@ -493,7 +517,9 @@ I.sendDeviceKeyEvent(3);
 
 #### Parameters
 
--   `keyValue` **[number][8]** Device specific key valueAppium: support only Android
+-   `keyValue` **[number][10]** Device specific key value
+
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### openNotifications
 
@@ -503,7 +529,7 @@ Open the notifications panel on the device.
 I.openNotifications();
 ```
 
-Appium: support only Android
+Returns **[Promise][4]&lt;void>** Appium: support only Android
 
 ### makeTouchAction
 
@@ -511,18 +537,18 @@ The Touch Action API provides the basis of all gestures that can be
 automated in Appium. At its core is the ability to chain together ad hoc
 individual actions, which will then be applied to an element in the
 application on the device.
-[See complete documentation][9]
+[See complete documentation][11]
 
 ```js
 I.makeTouchAction("~buttonStartWebviewCD", 'tap');
 ```
 
-Appium: support Android and iOS
-
 #### Parameters
 
 -   `locator`  
 -   `action`  
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### tap
 
@@ -538,6 +564,8 @@ Shortcut for `makeTouchAction`
 
 -   `locator` **any** 
 
+Returns **[Promise][4]&lt;void>** 
+
 ### swipe
 
 Perform a swipe on the screen or an element.
@@ -547,14 +575,16 @@ let locator = "#io.selendroid.testapp:id/LinearLayout1";
 I.swipe(locator, 800, 1200, 1000);
 ```
 
-[See complete reference][10]
+[See complete reference][12]
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** 
--   `xoffset` **[number][8]** 
--   `yoffset` **[number][8]** 
--   `speed` **[number][8]** (optional), 1000 by defaultAppium: support Android and iOS (optional, default `1000`)
+-   `locator` **([string][5] \| [object][8])** 
+-   `xoffset` **[number][10]** 
+-   `yoffset` **[number][10]** 
+-   `speed` **[number][10]** (optional), 1000 by default (optional, default `1000`)
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### performSwipe
 
@@ -566,8 +596,8 @@ I.performswipe(100,200);
 
 #### Parameters
 
--   `from` **[number][8]** 
--   `to` **[number][8]** Appium: support Android and iOS
+-   `from` **[number][10]** 
+-   `to` **[number][10]** Appium: support Android and iOS
 
 ### swipeDown
 
@@ -582,9 +612,11 @@ I.swipeDown(locator, 1200, 1000); // set offset and speed
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** 
--   `yoffset` **[number][8]?** (optional) (optional, default `1000`)
--   `speed` **[number][8]** (optional), 1000 by defaultAppium: support Android and iOS (optional, default `1000`)
+-   `locator` **([string][5] \| [object][8])** 
+-   `yoffset` **[number][10]?** (optional) (optional, default `1000`)
+-   `speed` **[number][10]** (optional), 1000 by default (optional, default `1000`)
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### swipeLeft
 
@@ -599,9 +631,11 @@ I.swipeLeft(locator, 1200, 1000); // set offset and speed
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** 
--   `xoffset` **[number][8]?** (optional) (optional, default `1000`)
--   `speed` **[number][8]** (optional), 1000 by defaultAppium: support Android and iOS (optional, default `1000`)
+-   `locator` **([string][5] \| [object][8])** 
+-   `xoffset` **[number][10]?** (optional) (optional, default `1000`)
+-   `speed` **[number][10]** (optional), 1000 by default (optional, default `1000`)
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### swipeRight
 
@@ -616,9 +650,11 @@ I.swipeRight(locator, 1200, 1000); // set offset and speed
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** 
--   `xoffset` **[number][8]?** (optional) (optional, default `1000`)
--   `speed` **[number][8]** (optional), 1000 by defaultAppium: support Android and iOS (optional, default `1000`)
+-   `locator` **([string][5] \| [object][8])** 
+-   `xoffset` **[number][10]?** (optional) (optional, default `1000`)
+-   `speed` **[number][10]** (optional), 1000 by default (optional, default `1000`)
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### swipeUp
 
@@ -633,9 +669,11 @@ I.swipeUp(locator, 1200, 1000); // set offset and speed
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** 
--   `yoffset` **[number][8]?** (optional) (optional, default `1000`)
--   `speed` **[number][8]** (optional), 1000 by defaultAppium: support Android and iOS (optional, default `1000`)
+-   `locator` **([string][5] \| [object][8])** 
+-   `yoffset` **[number][10]?** (optional) (optional, default `1000`)
+-   `speed` **[number][10]** (optional), 1000 by default (optional, default `1000`)
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### swipeTo
 
@@ -653,12 +691,14 @@ I.swipeTo(
 
 #### Parameters
 
--   `searchableLocator` **[string][4]** 
--   `scrollLocator` **[string][4]** 
--   `direction` **[string][4]** 
--   `timeout` **[number][8]** 
--   `offset` **[number][8]** 
--   `speed` **[number][8]** Appium: support Android and iOS
+-   `searchableLocator` **[string][5]** 
+-   `scrollLocator` **[string][5]** 
+-   `direction` **[string][5]** 
+-   `timeout` **[number][10]** 
+-   `offset` **[number][10]** 
+-   `speed` **[number][10]** 
+
+Returns **[Promise][4]&lt;void>** Appium: support Android and iOS
 
 ### touchPerform
 
@@ -689,7 +729,7 @@ Appium: support Android and iOS
 
 #### Parameters
 
--   `actions` **[Array][11]** Array of touch actions
+-   `actions` **[Array][6]** Array of touch actions
 
 ### pullFile
 
@@ -701,12 +741,12 @@ I.pullFile('/storage/emulated/0/DCIM/logo.png', 'my/path');
 I.pullFile('/storage/emulated/0/DCIM/logo.png', output_dir);
 ```
 
-Appium: support Android and iOS
-
 #### Parameters
 
--   `path`  
--   `dest`  
+-   `path` **[string][5]** 
+-   `dest` **[string][5]** 
+
+Returns **[Promise][4]&lt;[string][5]>** Appium: support Android and iOS
 
 ### shakeDevice
 
@@ -716,7 +756,7 @@ Perform a shake action on the device.
 I.shakeDevice();
 ```
 
-Appium: support only iOS
+Returns **[Promise][4]&lt;void>** Appium: support only iOS
 
 ### rotate
 
@@ -726,9 +766,7 @@ Perform a rotation gesture centered on the specified element.
 I.rotate(120, 120)
 ```
 
-See corresponding [webdriverio reference][12].
-
-Appium: support only iOS
+See corresponding [webdriverio reference][13].
 
 #### Parameters
 
@@ -739,18 +777,20 @@ Appium: support only iOS
 -   `rotation`  
 -   `touchCount`  
 
+Returns **[Promise][4]&lt;void>** Appium: support only iOS
+
 ### setImmediateValue
 
 Set immediate value in app.
 
-See corresponding [webdriverio reference][13].
-
-Appium: support only iOS
+See corresponding [webdriverio reference][14].
 
 #### Parameters
 
 -   `id`  
 -   `value`  
+
+Returns **[Promise][4]&lt;void>** Appium: support only iOS
 
 ### simulateTouchId
 
@@ -762,12 +802,12 @@ I.touchId(true); // simulates valid fingerprint
 I.touchId(false); // simulates invalid fingerprint
 ```
 
-Appium: support only iOS
-TODO: not tested
-
 #### Parameters
 
 -   `match`  
+
+Returns **[Promise][4]&lt;void>** Appium: support only iOS
+TODO: not tested
 
 ### closeApp
 
@@ -777,7 +817,7 @@ Close the given application.
 I.closeApp();
 ```
 
-Appium: support only iOS
+Returns **[Promise][4]&lt;void>** Appium: support only iOS
 
 ### appendField
 
@@ -790,8 +830,8 @@ I.appendField('#myTextField', 'appended');
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator
--   `value` **[string][4]** text value to append.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator
+-   `value` **[string][5]** text value to append.
 
 ### checkOption
 
@@ -808,8 +848,8 @@ I.checkOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator. (optional, default `null`)
+-   `field` **([string][5] \| [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. (optional, default `null`)
 
 ### click
 
@@ -837,8 +877,8 @@ I.click({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
 
 ### dontSeeCheckboxIsChecked
 
@@ -852,7 +892,7 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### dontSeeElement
 
@@ -864,7 +904,7 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|Strict locator.
 
 ### dontSeeInField
 
@@ -878,8 +918,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][4]** value to check.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][5]** value to check.
 
 ### dontSee
 
@@ -893,8 +933,8 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 #### Parameters
 
--   `text` **[string][4]** which is not present.
--   `context` **([string][4] \| [object][6])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. (optional, default `null`)
+-   `text` **[string][5]** which is not present.
+-   `context` **([string][5] \| [object][8])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. (optional, default `null`)
 
 ### fillField
 
@@ -914,8 +954,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
--   `value` **([string][4] \| [object][6])** text value to fill.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **([string][5] \| [object][8])** text value to fill.
 
 ### grabTextFromAll
 
@@ -928,9 +968,9 @@ let pins = await I.grabTextFromAll('#pin li');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][11]&lt;[string][4]>>** attribute value
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** attribute value
 
 ### grabTextFrom
 
@@ -945,9 +985,9 @@ If multiple elements found returns first element.
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][4]>** attribute value
+Returns **[Promise][4]&lt;[string][5]>** attribute value
 
 ### grabNumberOfVisibleElements
 
@@ -960,9 +1000,9 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[number][8]>** number of visible elements
+Returns **[Promise][4]&lt;[number][10]>** number of visible elements
 
 ### grabAttributeFrom
 
@@ -978,10 +1018,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `attr` **[string][4]** attribute name.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][5]** attribute name.
 
-Returns **[Promise][14]&lt;[string][4]>** attribute value
+Returns **[Promise][4]&lt;[string][5]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -995,10 +1035,10 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `attr` **[string][4]** attribute name.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][5]** attribute name.
 
-Returns **[Promise][14]&lt;[Array][11]&lt;[string][4]>>** attribute value
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** attribute value
 
 ### grabValueFromAll
 
@@ -1011,9 +1051,9 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][11]&lt;[string][4]>>** attribute value
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** attribute value
 
 ### grabValueFrom
 
@@ -1027,9 +1067,9 @@ let email = await I.grabValueFrom('input[name=email]');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][4]>** attribute value
+Returns **[Promise][4]&lt;[string][5]>** attribute value
 
 ### saveScreenshot
 
@@ -1042,7 +1082,9 @@ I.saveScreenshot('debug.png');
 
 #### Parameters
 
--   `fileName` **[string][4]** file name to save.
+-   `fileName` **[string][5]** file name to save.
+
+Returns **[Promise][4]&lt;void>** 
 
 ### scrollIntoView
 
@@ -1056,7 +1098,7 @@ I.scrollIntoView('#submit', { behavior: "smooth", block: "center", inline: "cent
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 -   `scrollIntoViewOptions` **ScrollIntoViewOptions** see [https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView][15].Supported only for web testing
 
 ### seeCheckboxIsChecked
@@ -1071,7 +1113,7 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### seeElement
 
@@ -1084,7 +1126,7 @@ I.seeElement('#modal');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 
 ### seeInField
 
@@ -1100,8 +1142,8 @@ I.seeInField('#searchform input','Search');
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][4]** value to check.
+-   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][5]** value to check.
 
 ### see
 
@@ -1116,8 +1158,8 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 #### Parameters
 
--   `text` **[string][4]** expected on page.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. (optional, default `null`)
+-   `text` **[string][5]** expected on page.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. (optional, default `null`)
 
 ### selectOption
 
@@ -1142,8 +1184,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 
 #### Parameters
 
--   `select` **([string][4] \| [object][6])** field located by label|name|CSS|XPath|strict locator.
--   `option` **([string][4] \| [Array][11]&lt;any>)** visible text or value of option.Supported only for web testing
+-   `select` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `option` **([string][5] \| [Array][6]&lt;any>)** visible text or value of option.Supported only for web testing
 
 ### waitForElement
 
@@ -1157,8 +1199,8 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][8]?** (optional, `1` by default) time in seconds to wait (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait (optional, default `null`)
 
 ### waitForVisible
 
@@ -1171,8 +1213,8 @@ I.waitForVisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][8]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
 
 ### waitForInvisible
 
@@ -1185,8 +1227,8 @@ I.waitForInvisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][8]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
 
 ### waitForText
 
@@ -1201,9 +1243,9 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 #### Parameters
 
--   `text` **[string][4]** to wait for.
--   `sec` **[number][8]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
--   `context` **([string][4] \| [object][6])?** (optional) element located by CSS|XPath|strict locator. (optional, default `null`)
+-   `text` **[string][5]** to wait for.
+-   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
+-   `context` **([string][5] \| [object][8])?** (optional) element located by CSS|XPath|strict locator. (optional, default `null`)
 
 ### useWebDriverTo
 
@@ -1223,7 +1265,7 @@ I.useWebDriverTo('open multiple windows', async ({ browser }) {
 
 #### Parameters
 
--   `description` **[string][4]** used to show in logs.
+-   `description` **[string][5]** used to show in logs.
 -   `fn` **[function][17]** async functuion that executed with WebDriver helper as argument
 
 ### \_isShadowLocator
@@ -1232,7 +1274,7 @@ Check if locator is type of "Shadow"
 
 #### Parameters
 
--   `locator` **[object][6]** 
+-   `locator` **[object][8]** 
 
 ### \_locateShadow
 
@@ -1240,7 +1282,7 @@ Locate Element within the Shadow Dom
 
 #### Parameters
 
--   `locator` **[object][6]** 
+-   `locator` **[object][8]** 
 
 ### \_smartWait
 
@@ -1248,7 +1290,7 @@ Smart Wait to locate an element
 
 #### Parameters
 
--   `locator` **[object][6]** 
+-   `locator` **[object][8]** 
 
 ### \_locate
 
@@ -1261,7 +1303,7 @@ this.helpers['WebDriver']._locate({name: 'password'}).then //...
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `smartWait`   (optional, default `false`)
 
 ### \_locateCheckable
@@ -1274,7 +1316,7 @@ this.helpers['WebDriver']._locateCheckable('I agree with terms and conditions').
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
 ### \_locateClickable
 
@@ -1287,7 +1329,7 @@ const els = await this.helpers.WebDriver._locateClickable('Next page', '.pages')
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `context`  
 
 ### \_locateFields
@@ -1300,7 +1342,7 @@ this.helpers['WebDriver']._locateFields('Your email').then // ...
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
 ### defineTimeout
 
@@ -1330,7 +1372,7 @@ I.amOnPage('/login'); // opens a login page
 
 #### Parameters
 
--   `url` **[string][4]** url path or global url.
+-   `url` **[string][5]** url path or global url.
 
 ### forceClick
 
@@ -1361,8 +1403,8 @@ I.forceClick({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
 
 ### doubleClick
 
@@ -1378,8 +1420,8 @@ I.doubleClick('.btn.edit');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
 
 ### rightClick
 
@@ -1396,8 +1438,8 @@ I.rightClick('Click me', '.context');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator.{{ react }} (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** clickable element located by CSS|XPath|strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator.{{ react }} (optional, default `null`)
 
 ### forceRightClick
 
@@ -1418,8 +1460,8 @@ I.forceRightClick('Menu');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
 
 ### clearField
 
@@ -1434,7 +1476,7 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` **([string][4] \| [object][6])** field located by label|name|CSS|XPath|strict locator.
+-   `editable` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
 
 ### attachFile
 
@@ -1449,8 +1491,8 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][4]** local file path relative to codecept.json config file.
+-   `locator` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `pathToFile` **[string][5]** local file path relative to codecept.json config file.
     Appium: not tested
 
 ### uncheckOption
@@ -1468,8 +1510,8 @@ I.uncheckOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][4] \| [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator.
+-   `field` **([string][5] \| [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator.
     Appium: not tested (optional, default `null`)
 
 ### grabHTMLFromAll
@@ -1484,9 +1526,9 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `element` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][11]&lt;[string][4]>>** HTML code for an element
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** HTML code for an element
 
 ### grabHTMLFrom
 
@@ -1501,9 +1543,9 @@ let postHTML = await I.grabHTMLFrom('#post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `element` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][4]>** HTML code for an element
+Returns **[Promise][4]&lt;[string][5]>** HTML code for an element
 
 ### seeTextEquals
 
@@ -1515,8 +1557,8 @@ I.seeTextEquals('text', 'h1');
 
 #### Parameters
 
--   `text` **[string][4]** element value to check.
--   `context` **([string][4] \| [object][6])?** element located by CSS|XPath|strict locator. (optional, default `null`)
+-   `text` **[string][5]** element value to check.
+-   `context` **([string][5] \| [object][8])?** element located by CSS|XPath|strict locator. (optional, default `null`)
 
 ### seeElementInDOM
 
@@ -1529,7 +1571,7 @@ I.seeElementInDOM('#modal');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
 ### dontSeeElementInDOM
 
@@ -1541,7 +1583,7 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|Strict locator.
 
 ### seeInSource
 
@@ -1553,7 +1595,7 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 #### Parameters
 
--   `text` **[string][4]** value to check.
+-   `text` **[string][5]** value to check.
 
 ### grabSource
 
@@ -1564,7 +1606,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][14]&lt;[string][4]>** source code
+Returns **[Promise][4]&lt;[string][5]>** source code
 
 ### grabBrowserLogs
 
@@ -1576,7 +1618,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **([Promise][14]&lt;[Array][11]&lt;[object][6]>> | [undefined][19])** all browser logs
+Returns **([Promise][4]&lt;[Array][6]&lt;[object][8]>> | [undefined][19])** all browser logs
 
 ### dontSeeInSource
 
@@ -1589,7 +1631,7 @@ I.dontSeeInSource('<!--'); // no comments in source
 #### Parameters
 
 -   `text`  
--   `value` **[string][4]** to check.
+-   `value` **[string][5]** to check.
 
 ### seeNumberOfElements
 
@@ -1602,8 +1644,8 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `num` **[number][8]** number of elements.{{ react }}
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][10]** number of elements.{{ react }}
 
 ### seeNumberOfVisibleElements
 
@@ -1616,8 +1658,8 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `num` **[number][8]** number of elements.{{ react }}
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][10]** number of elements.{{ react }}
 
 ### seeAttributesOnElements
 
@@ -1629,8 +1671,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
--   `attributes` **[object][6]** attributes and their values to check.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
+-   `attributes` **[object][8]** attributes and their values to check.
 
 ### scrollTo
 
@@ -1644,9 +1686,9 @@ I.scrollTo('#submit', 5, 5);
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][8]** (optional, `0` by default) X-axis offset. (optional, default `0`)
--   `offsetY` **[number][8]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. (optional, default `0`)
+-   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
 
 ### moveCursorTo
 
@@ -1660,11 +1702,11 @@ I.moveCursorTo('#submit', 5,5);
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 -   `xOffset`  
 -   `yOffset`  
--   `offsetX` **[number][8]** (optional, `0` by default) X-axis offset. (optional, default `0`)
--   `offsetY` **[number][8]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
+-   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. (optional, default `0`)
+-   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
 
 ### saveElementScreenshot
 
@@ -1677,8 +1719,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
--   `fileName` **[string][4]** file name to save.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
+-   `fileName` **[string][5]** file name to save.
 
 ### type
 
@@ -1700,8 +1742,8 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][8]?** (optional) delay in ms between key presses (optional, default `null`)
--   `key` **([string][4] \| [Array][11]&lt;[string][4]>)** or array of keys to type.
+-   `delay` **[number][10]?** (optional) delay in ms between key presses (optional, default `null`)
+-   `key` **([string][5] \| [Array][6]&lt;[string][5]>)** or array of keys to type.
 
 ### dragAndDrop
 
@@ -1713,8 +1755,8 @@ I.dragAndDrop('#dragHandle', '#container');
 
 #### Parameters
 
--   `srcElement` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.
--   `destElement` **([string][4] \| [object][6])** located by CSS|XPath|strict locator.Appium: not tested
+-   `srcElement` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
+-   `destElement` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.Appium: not tested
 
 ### dragSlider
 
@@ -1728,8 +1770,8 @@ I.dragSlider('#slider', -70);
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][8]** position to drag. (optional, default `0`)
+-   `locator` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `offsetX` **[number][10]** position to drag. (optional, default `0`)
 
 ### grabAllWindowHandles
 
@@ -1740,7 +1782,7 @@ Useful for referencing a specific handle when calling `I.switchToWindow(handle)`
 const windows = await I.grabAllWindowHandles();
 ```
 
-Returns **[Promise][14]&lt;[Array][11]&lt;[string][4]>>** 
+Returns **[Promise][4]&lt;[Array][6]&lt;[string][5]>>** 
 
 ### grabCurrentWindowHandle
 
@@ -1751,7 +1793,7 @@ Useful for referencing it when calling `I.switchToWindow(handle)`
 const window = await I.grabCurrentWindowHandle();
 ```
 
-Returns **[Promise][14]&lt;[string][4]>** 
+Returns **[Promise][4]&lt;[string][5]>** 
 
 ### switchToWindow
 
@@ -1769,7 +1811,7 @@ await I.switchToWindow( window );
 
 #### Parameters
 
--   `window` **[string][4]** name of window handle.
+-   `window` **[string][5]** name of window handle.
 
 ### closeOtherTabs
 
@@ -1790,7 +1832,7 @@ I.switchTo(); // switch back to main page
 
 #### Parameters
 
--   `locator` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator. (optional, default `null`)
+-   `locator` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. (optional, default `null`)
 
 ### grabNumberOfOpenTabs
 
@@ -1801,7 +1843,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][14]&lt;[number][8]>** number of open tabs
+Returns **[Promise][4]&lt;[number][10]>** number of open tabs
 
 ### scrollPageToTop
 
@@ -1828,7 +1870,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][14]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][4]&lt;PageScrollPosition>** scroll position
 
 ### setGeoLocation
 
@@ -1841,9 +1883,9 @@ I.setGeoLocation(121.21, 11.56, 10);
 
 #### Parameters
 
--   `latitude` **[number][8]** to set.
--   `longitude` **[number][8]** to set
--   `altitude` **[number][8]?** (optional, null by default) to set (optional, default `null`)
+-   `latitude` **[number][10]** to set.
+-   `longitude` **[number][10]** to set
+-   `altitude` **[number][10]?** (optional, null by default) to set (optional, default `null`)
 
 ### grabGeoLocation
 
@@ -1854,7 +1896,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let geoLocation = await I.grabGeoLocation();
 ```
 
-Returns **[Promise][14]&lt;{latitude: [number][8], longitude: [number][8], altitude: [number][8]}>** 
+Returns **[Promise][4]&lt;{latitude: [number][10], longitude: [number][10], altitude: [number][10]}>** 
 
 ### grabElementBoundingRect
 
@@ -1878,39 +1920,39 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 
 #### Parameters
 
--   `locator` **([string][4] \| [object][6])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `prop`  
--   `elementSize` **[string][4]?** x, y, width or height of the given element.
+-   `elementSize` **[string][5]?** x, y, width or height of the given element.
 
-Returns **([Promise][14]&lt;DOMRect> | [Promise][14]&lt;[number][8]>)** Element bounding rectangle
+Returns **([Promise][4]&lt;DOMRect> | [Promise][4]&lt;[number][10]>)** Element bounding rectangle
 
-[1]: https://codecept.io/helpers/WebDriver/
+[1]: http://codecept.io/helpers/WebDriver/
 
-[2]: https://appium.io/
+[2]: http://appium.io/
 
 [3]: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md
 
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[5]: https://webdriver.io/api/mobile/setNetworkConnection.html
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[7]: https://developer.android.com/reference/android/view/KeyEvent.html
+[7]: http://webdriver.io/api/mobile/setNetworkConnection.html
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[9]: https://webdriver.io/api/mobile/touchAction.html
+[9]: https://developer.android.com/reference/android/view/KeyEvent.html
 
-[10]: https://webdriver.io/api/mobile/swipe.html
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[11]: http://webdriver.io/api/mobile/touchAction.html
 
-[12]: https://webdriver.io/api/mobile/rotate.html
+[12]: http://webdriver.io/api/mobile/swipe.html
 
-[13]: https://webdriver.io/api/mobile/setImmediateValue.html
+[13]: http://webdriver.io/api/mobile/rotate.html
 
-[14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[14]: http://webdriver.io/api/mobile/setImmediateValue.html
 
 [15]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
 

--- a/docs/helpers/GraphQLDataFactory.md
+++ b/docs/helpers/GraphQLDataFactory.md
@@ -219,7 +219,7 @@ I.mutateMultiple('createUser', 3, { age: 25 });
 
 [2]: https://www.npmjs.com/package/faker
 
-[3]: https://codecept.io/helpers/GraphQL/
+[3]: http://codecept.io/helpers/GraphQL/
 
 [4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -1194,10 +1194,10 @@ I.waitToHide('#popup');
 
 [11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[12]: https://electron.atom.io/docs/api/web-contents/#webcontentssendinputeventevent
+[12]: http://electron.atom.io/docs/api/web-contents/#webcontentssendinputeventevent
 
 [13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
 [14]: https://github.com/segmentio/nightmare/blob/master/Readme.md#cookiessetcookie
 
-[15]: https://electron.atom.io/docs/api/web-contents/#contentssendinputeventevent
+[15]: http://electron.atom.io/docs/api/web-contents/#contentssendinputeventevent

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -208,6 +208,8 @@ Add the 'dialog' event listener to a page
 
 -   `page`  
 
+Returns **[Promise][7]&lt;void>** 
+
 ### _contextLocator
 
 Grab Locator if called within Context
@@ -216,9 +218,23 @@ Grab Locator if called within Context
 
 -   `locator` **any** 
 
+### _evaluateHandeInContext
+
+#### Parameters
+
+-   `args` **...any** 
+
+Returns **[Promise][7]&lt;any>** 
+
 ### _getPageUrl
 
 Gets page URL including hash.
+
+Returns **[Promise][7]&lt;any>** 
+
+### _getType
+
+Returns **[Promise][7]&lt;void>** 
 
 ### _locate
 
@@ -232,6 +248,8 @@ const elements = await this.helpers['Playwright']._locate({name: 'password'});
 #### Parameters
 
 -   `locator`  
+
+Returns **[Promise][7]&lt;any>** 
 
 ### _locateCheckable
 
@@ -247,6 +265,8 @@ this.helpers['Playwright']._locateCheckable('I agree with terms and conditions')
 -   `locator`  
 -   `providedContext`   
 
+Returns **[Promise][7]&lt;any>** 
+
 ### _locateClickable
 
 Find a clickable element by providing human readable text:
@@ -258,6 +278,8 @@ this.helpers['Playwright']._locateClickable('Next page').then // ...
 #### Parameters
 
 -   `locator`  
+
+Returns **[Promise][7]&lt;any>** 
 
 ### _locateFields
 
@@ -271,19 +293,37 @@ this.helpers['Playwright']._locateFields('Your email').then // ...
 
 -   `locator`  
 
+Returns **[Promise][7]&lt;any>** 
+
 ### _setPage
 
 Set current page
 
 #### Parameters
 
--   `page` **[object][7]** page to set
+-   `page` **[object][8]** page to set
+
+Returns **[Promise][7]&lt;void>** 
+
+### _startBrowser
+
+Returns **[Promise][7]&lt;void>** 
+
+### _stopBrowser
+
+Returns **[Promise][7]&lt;void>** 
+
+### _waitForAction
+
+Returns **[Promise][7]&lt;void>** 
 
 ### acceptPopup
 
 Accepts the active JavaScript native popup window, as created by window.alert|window.confirm|window.prompt.
 Don't confuse popups with modal windows, as created by [various
-libraries][8].
+libraries][9].
+
+Returns **[Promise][7]&lt;void>** 
 
 ### amAcceptingPopups
 
@@ -296,6 +336,8 @@ I.click('#triggerPopup');
 I.acceptPopup();
 ```
 
+Returns **[Promise][7]&lt;void>** 
+
 ### amCancellingPopups
 
 Set the automatic popup response to Cancel/Dismiss.
@@ -306,6 +348,8 @@ I.amCancellingPopups();
 I.click('#triggerPopup');
 I.cancelPopup();
 ```
+
+Returns **[Promise][7]&lt;void>** 
 
 ### amOnPage
 
@@ -320,7 +364,7 @@ I.amOnPage('/login'); // opens a login page
 
 #### Parameters
 
--   `url` **[string][9]** url path or global url.
+-   `url` **[string][10]** url path or global url.
 
 ### appendField
 
@@ -333,8 +377,8 @@ I.appendField('#myTextField', 'appended');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator
--   `value` **[string][9]** text value to append.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator
+-   `value` **[string][10]** text value to append.
 
 ### attachFile
 
@@ -349,12 +393,14 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][9]** local file path relative to codecept.json config file.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `pathToFile` **[string][10]** local file path relative to codecept.json config file.
 
 ### cancelPopup
 
 Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
+
+Returns **[Promise][7]&lt;void>** 
 
 ### checkOption
 
@@ -371,8 +417,8 @@ I.checkOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][10] | [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
 ### clearCookie
 
@@ -386,7 +432,7 @@ I.clearCookie('test');
 
 #### Parameters
 
--   `cookie` **[string][9]?** (optional, `null` by default) cookie name 
+-   `cookie` **[string][10]?** (optional, `null` by default) cookie name 
 
 ### clearField
 
@@ -401,7 +447,7 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `editable` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
 ### click
 
@@ -429,8 +475,8 @@ I.click({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### clickLink
 
@@ -441,6 +487,8 @@ Clicks link and waits for navigation (deprecated)
 -   `locator`  
 -   `context`   
 
+Returns **[Promise][7]&lt;void>** 
+
 ### closeCurrentTab
 
 Close current tab and switches to previous.
@@ -449,6 +497,8 @@ Close current tab and switches to previous.
 I.closeCurrentTab();
 ```
 
+Returns **[Promise][7]&lt;void>** 
+
 ### closeOtherTabs
 
 Close all tabs except for the current one.
@@ -456,6 +506,8 @@ Close all tabs except for the current one.
 ```js
 I.closeOtherTabs();
 ```
+
+Returns **[Promise][7]&lt;void>** 
 
 ### dontSee
 
@@ -469,8 +521,8 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 #### Parameters
 
--   `text` **[string][9]** which is not present.
--   `context` **([string][9] | [object][7])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+-   `text` **[string][10]** which is not present.
+-   `context` **([string][10] | [object][8])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
 
 ### dontSeeCheckboxIsChecked
 
@@ -484,7 +536,7 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### dontSeeCookie
 
@@ -496,7 +548,7 @@ I.dontSeeCookie('auth'); // no auth cookie
 
 #### Parameters
 
--   `name` **[string][9]** cookie name.
+-   `name` **[string][10]** cookie name.
 
 ### dontSeeCurrentUrlEquals
 
@@ -510,7 +562,8 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
+    async
 
 ### dontSeeElement
 
@@ -522,7 +575,7 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|Strict locator.
 
 ### dontSeeElementInDOM
 
@@ -534,7 +587,7 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|Strict locator.
 
 ### dontSeeInCurrentUrl
 
@@ -542,7 +595,7 @@ Checks that current url does not contain a provided fragment.
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
 
 ### dontSeeInField
 
@@ -556,8 +609,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][9]** value to check.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][10]** value to check.
 
 ### dontSeeInSource
 
@@ -570,7 +623,7 @@ I.dontSeeInSource('<!--'); // no comments in source
 #### Parameters
 
 -   `text`  
--   `value` **[string][9]** to check.
+-   `value` **[string][10]** to check.
 
 ### dontSeeInTitle
 
@@ -582,7 +635,7 @@ I.dontSeeInTitle('Error');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### doubleClick
 
@@ -598,8 +651,8 @@ I.doubleClick('.btn.edit');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### dragAndDrop
 
@@ -611,8 +664,8 @@ I.dragAndDrop('#dragHandle', '#container');
 
 #### Parameters
 
--   `srcElement` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `destElement` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `srcElement` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `destElement` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
 ### dragSlider
 
@@ -626,8 +679,8 @@ I.dragSlider('#slider', -70);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][10]** position to drag. 
+-   `locator` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** position to drag. 
 
 ### executeScript
 
@@ -654,10 +707,10 @@ If a function returns a Promise it will wait for its resolution.
 
 #### Parameters
 
--   `fn` **([string][9] | [function][11])** function to be executed in browser context.
+-   `fn` **([string][10] | [function][12])** function to be executed in browser context.
 -   `arg` **any?** optional argument to pass to the function
 
-Returns **[Promise][12]&lt;any>** 
+Returns **[Promise][7]&lt;any>** 
 
 ### fillField
 
@@ -677,8 +730,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **([string][9] | [object][7])** text value to fill.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **([string][10] | [object][8])** text value to fill.
 
 ### forceClick
 
@@ -709,8 +762,8 @@ I.forceClick({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### grabAttributeFrom
 
@@ -724,10 +777,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `attr` **[string][9]** attribute name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][10]** attribute name.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][7]&lt;[string][10]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -740,10 +793,10 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `attr` **[string][9]** attribute name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][10]** attribute name.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][7]&lt;[Array][13]&lt;[string][10]>>** attribute value
 
 ### grabBrowserLogs
 
@@ -754,7 +807,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **[Promise][12]&lt;[Array][13]&lt;any>>** 
+Returns **[Promise][7]&lt;[Array][13]&lt;any>>** 
 
 ### grabCookie
 
@@ -769,9 +822,9 @@ assert(cookie.value, '123456');
 
 #### Parameters
 
--   `name` **[string][9]?** cookie name. 
+-   `name` **[string][10]?** cookie name. 
 
-Returns **([Promise][12]&lt;[string][9]> | [Promise][12]&lt;[Array][13]&lt;[string][9]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][7]&lt;[string][10]> | [Promise][7]&lt;[Array][13]&lt;[string][10]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCssPropertyFrom
 
@@ -785,10 +838,10 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][9]** CSS property name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][10]** CSS property name.
 
-Returns **[Promise][12]&lt;[string][9]>** CSS value
+Returns **[Promise][7]&lt;[string][10]>** CSS value
 
 ### grabCssPropertyFromAll
 
@@ -801,10 +854,10 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][9]** CSS property name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][10]** CSS property name.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** CSS value
+Returns **[Promise][7]&lt;[Array][13]&lt;[string][10]>>** CSS value
 
 ### grabCurrentUrl
 
@@ -816,7 +869,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** current URL
+Returns **[Promise][7]&lt;[string][10]>** current URL
 
 ### grabDataFromPerformanceTiming
 
@@ -863,11 +916,11 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 -   `prop`  
--   `elementSize` **[string][9]?** x, y, width or height of the given element.
+-   `elementSize` **[string][10]?** x, y, width or height of the given element.
 
-Returns **([Promise][12]&lt;DOMRect> | [Promise][12]&lt;[number][10]>)** Element bounding rectangle
+Returns **([Promise][7]&lt;DOMRect> | [Promise][7]&lt;[number][11]>)** Element bounding rectangle
 
 ### grabHTMLFrom
 
@@ -882,9 +935,9 @@ let postHTML = await I.grabHTMLFrom('#post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `element` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** HTML code for an element
+Returns **[Promise][7]&lt;[string][10]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -898,9 +951,9 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `element` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** HTML code for an element
+Returns **[Promise][7]&lt;[Array][13]&lt;[string][10]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -911,7 +964,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][12]&lt;[number][10]>** number of open tabs
+Returns **[Promise][7]&lt;[number][11]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -924,9 +977,9 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[number][10]>** number of visible elements
+Returns **[Promise][7]&lt;[number][11]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -937,7 +990,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][12]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][7]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -947,7 +1000,7 @@ Grab the text within the popup. If no popup is visible then it will return null
 await I.grabPopupText();
 ```
 
-Returns **[Promise][12]&lt;([string][9] | null)>** 
+Returns **[Promise][7]&lt;([string][10] | null)>** 
 
 ### grabSource
 
@@ -958,7 +1011,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** source code
+Returns **[Promise][7]&lt;[string][10]>** source code
 
 ### grabTextFrom
 
@@ -973,9 +1026,9 @@ If multiple elements found returns first element.
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][7]&lt;[string][10]>** attribute value
 
 ### grabTextFromAll
 
@@ -988,9 +1041,9 @@ let pins = await I.grabTextFromAll('#pin li');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][7]&lt;[Array][13]&lt;[string][10]>>** attribute value
 
 ### grabTitle
 
@@ -1001,7 +1054,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** title
+Returns **[Promise][7]&lt;[string][10]>** title
 
 ### grabValueFrom
 
@@ -1015,9 +1068,9 @@ let email = await I.grabValueFrom('input[name=email]');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][7]&lt;[string][10]>** attribute value
 
 ### grabValueFromAll
 
@@ -1030,9 +1083,9 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][7]&lt;[Array][13]&lt;[string][10]>>** attribute value
 
 ### handleDownloads
 
@@ -1050,7 +1103,9 @@ I.waitForFile('downloads/avatar.jpg', 5);
 
 #### Parameters
 
--   `fileName` **[string][9]?** set filename for downloaded file 
+-   `fileName` **[string][10]?** set filename for downloaded file 
+
+Returns **[Promise][7]&lt;void>** 
 
 ### haveRequestHeaders
 
@@ -1064,7 +1119,9 @@ I.haveRequestHeaders({
 
 #### Parameters
 
--   `customHeaders` **[object][7]** headers to set
+-   `customHeaders` **[object][8]** headers to set
+
+Returns **[Promise][7]&lt;any>** 
 
 ### mockRoute
 
@@ -1078,8 +1135,10 @@ This method allows intercepting and mocking requests & responses. [Learn more ab
 
 #### Parameters
 
--   `url` **[string][9]?** URL, regex or pattern for to match URL
--   `handler` **[function][11]?** a function to process request
+-   `url` **[string][10]?** URL, regex or pattern for to match URL
+-   `handler` **[function][12]?** a function to process request
+
+Returns **[Promise][7]&lt;any>** 
 
 ### moveCursorTo
 
@@ -1093,9 +1152,9 @@ I.moveCursorTo('#submit', 5,5);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
 ### openNewTab
 
@@ -1115,6 +1174,8 @@ I.openNewTab({ isMobile: true });
 #### Parameters
 
 -   `options`  
+
+Returns **[Promise][7]&lt;void>** 
 
 ### pressKey
 
@@ -1179,7 +1240,7 @@ Some of the supported key names are:
 
 #### Parameters
 
--   `key` **([string][9] | [Array][13]&lt;[string][9]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][19]).
+-   `key` **([string][10] | [Array][13]&lt;[string][10]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][19]).
 
 ### pressKeyDown
 
@@ -1195,7 +1256,7 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][9]** name of key to press down.
+-   `key` **[string][10]** name of key to press down.
 
 ### pressKeyUp
 
@@ -1211,7 +1272,7 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][9]** name of key to release.
+-   `key` **[string][10]** name of key to release.
 
 ### refreshPage
 
@@ -1228,8 +1289,8 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` **[number][10]** width in pixels or `maximize`.
--   `height` **[number][10]** height in pixels.Unlike other drivers Playwright changes the size of a viewport, not the window!
+-   `width` **[number][11]** width in pixels or `maximize`.
+-   `height` **[number][11]** height in pixels.Unlike other drivers Playwright changes the size of a viewport, not the window!
     Playwright does not control the window of a browser so it can't adjust its real size.
     It also can't maximize a window.Update configuration to change real window size on start:```js
     // inside codecept.conf.js
@@ -1252,8 +1313,8 @@ I.rightClick('Click me', '.context');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
 ### saveElementScreenshot
 
@@ -1266,8 +1327,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `fileName` **[string][9]** file name to save.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `fileName` **[string][10]** file name to save.
 
 ### saveScreenshot
 
@@ -1282,7 +1343,7 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 #### Parameters
 
--   `fileName` **[string][9]** file name to save.
+-   `fileName` **[string][10]** file name to save.
 -   `fullPage` **[boolean][21]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
 ### scrollPageToBottom
@@ -1313,9 +1374,9 @@ I.scrollTo('#submit', 5, 5);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
 ### see
 
@@ -1330,8 +1391,8 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 #### Parameters
 
--   `text` **[string][9]** expected on page.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+-   `text` **[string][10]** expected on page.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
 
 ### seeAttributesOnElements
 
@@ -1343,8 +1404,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `attributes` **[object][7]** attributes and their values to check.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `attributes` **[object][8]** attributes and their values to check.
 
 ### seeCheckboxIsChecked
 
@@ -1358,7 +1419,7 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### seeCookie
 
@@ -1370,7 +1431,7 @@ I.seeCookie('Auth');
 
 #### Parameters
 
--   `name` **[string][9]** cookie name.
+-   `name` **[string][10]** cookie name.
 
 ### seeCssPropertiesOnElements
 
@@ -1382,8 +1443,8 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `cssProperties` **[object][7]** object with CSS properties and their values to check.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `cssProperties` **[object][8]** object with CSS properties and their values to check.
 
 ### seeCurrentUrlEquals
 
@@ -1398,7 +1459,7 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
 
 ### seeElement
 
@@ -1411,7 +1472,7 @@ I.seeElement('#modal');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
 ### seeElementInDOM
 
@@ -1424,7 +1485,7 @@ I.seeElementInDOM('#modal');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
 ### seeInCurrentUrl
 
@@ -1436,7 +1497,7 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 
 #### Parameters
 
--   `url` **[string][9]** a fragment to check
+-   `url` **[string][10]** a fragment to check
 
 ### seeInField
 
@@ -1452,8 +1513,8 @@ I.seeInField('#searchform input','Search');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][9]** value to check.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][10]** value to check.
 
 ### seeInPopup
 
@@ -1466,7 +1527,7 @@ I.seeInPopup('Popup text');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### seeInSource
 
@@ -1478,7 +1539,7 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### seeInTitle
 
@@ -1490,7 +1551,7 @@ I.seeInTitle('Home Page');
 
 #### Parameters
 
--   `text` **[string][9]** text value to check.
+-   `text` **[string][10]** text value to check.
 
 ### seeNumberOfElements
 
@@ -1503,8 +1564,8 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
 
 ### seeNumberOfVisibleElements
 
@@ -1517,8 +1578,8 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
 
 ### seeTextEquals
 
@@ -1530,8 +1591,8 @@ I.seeTextEquals('text', 'h1');
 
 #### Parameters
 
--   `text` **[string][9]** element value to check.
--   `context` **([string][9] | [object][7])?** element located by CSS|XPath|strict locator. 
+-   `text` **[string][10]** element value to check.
+-   `context` **([string][10] | [object][8])?** element located by CSS|XPath|strict locator. 
 
 ### seeTitleEquals
 
@@ -1543,7 +1604,7 @@ I.seeTitleEquals('Test title.');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### selectOption
 
@@ -1568,8 +1629,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 
 #### Parameters
 
--   `select` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
--   `option` **([string][9] | [Array][13]&lt;any>)** visible text or value of option.
+-   `select` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `option` **([string][10] | [Array][13]&lt;any>)** visible text or value of option.
 
 ### setCookie
 
@@ -1604,8 +1665,10 @@ If no handler is passed, all mock requests for the rote are disabled.
 
 #### Parameters
 
--   `url` **[string][9]?** URL, regex or pattern for to match URL
--   `handler` **[function][11]?** a function to process request
+-   `url` **[string][10]?** URL, regex or pattern for to match URL
+-   `handler` **[function][12]?** a function to process request
+
+Returns **[Promise][7]&lt;any>** 
 
 ### switchTo
 
@@ -1618,7 +1681,7 @@ I.switchTo(); // switch back to main page
 
 #### Parameters
 
--   `locator` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
 ### switchToNextTab
 
@@ -1631,7 +1694,9 @@ I.switchToNextTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
+
+Returns **[Promise][7]&lt;void>** 
 
 ### switchToPreviousTab
 
@@ -1644,7 +1709,9 @@ I.switchToPreviousTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
+
+Returns **[Promise][7]&lt;void>** 
 
 ### type
 
@@ -1666,8 +1733,8 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][10]?** (optional) delay in ms between key presses 
--   `key` **([string][9] | [Array][13]&lt;[string][9]>)** or array of keys to type.
+-   `delay` **[number][11]?** (optional) delay in ms between key presses 
+-   `key` **([string][10] | [Array][13]&lt;[string][10]>)** or array of keys to type.
 
 ### uncheckOption
 
@@ -1684,28 +1751,30 @@ I.uncheckOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][10] | [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
 ### usePlaywrightTo
 
 Use Playwright API inside a test.
 
 First argument is a description of an action.
-Second argument is async function that gets this helper as parameter.
+Second argument is function that gets this helper as parameter.
 
 { [`page`][22], [`context`][23] [`browser`][24] } objects from Playwright API are available.
 
 ```js
-I.usePlaywrightTo('emulate offline mode', async ({ context }) {
+I.usePlaywrightTo('emulate offline mode', ({ context }) {
   await context.setOffline(true);
 });
 ```
 
 #### Parameters
 
--   `description` **[string][9]** used to show in logs.
--   `fn` **[function][11]** async functuion that executed with Playwright helper as argument
+-   `description` **[string][10]** used to show in logs.
+-   `fn` **[function][12]** functuion that executed with Playwright helper as argument*
+
+Returns **[Promise][7]&lt;any>** 
 
 ### wait
 
@@ -1717,7 +1786,7 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` **[number][10]** number of second to wait.
+-   `sec` **[number][11]** number of second to wait.
 
 ### waitForClickable
 
@@ -1731,9 +1800,9 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 -   `waitTimeout`  
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
 
 ### waitForDetached
 
@@ -1746,8 +1815,8 @@ I.waitForDetached('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForElement
 
@@ -1761,8 +1830,8 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
 
 ### waitForEnabled
 
@@ -1771,8 +1840,8 @@ Element can be located by CSS or XPath.
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional) time in seconds to wait, 1 by default. 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional) time in seconds to wait, 1 by default. 
 
 ### waitForFunction
 
@@ -1791,9 +1860,9 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][9] | [function][11])** to be executed in browser context.
--   `argsOrSec` **([Array][13]&lt;any> | [number][10])?** (optional, `1` by default) arguments for function or seconds. 
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait 
+-   `fn` **([string][10] | [function][12])** to be executed in browser context.
+-   `argsOrSec` **([Array][13]&lt;any> | [number][11])?** (optional, `1` by default) arguments for function or seconds. 
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait 
 
 ### waitForInvisible
 
@@ -1806,8 +1875,8 @@ I.waitForInvisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForNavigation
 
@@ -1818,6 +1887,8 @@ See [Playwright's reference][25]
 #### Parameters
 
 -   `opts` **any**  
+
+Returns **[Promise][7]&lt;any>** 
 
 ### waitForRequest
 
@@ -1830,8 +1901,10 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 #### Parameters
 
--   `urlOrPredicate` **([string][9] | [function][11])** 
--   `sec` **[number][10]?** seconds to wait 
+-   `urlOrPredicate` **([string][10] | [function][12])** 
+-   `sec` **[number][11]?** seconds to wait 
+
+Returns **[Promise][7]&lt;any>** 
 
 ### waitForResponse
 
@@ -1844,8 +1917,10 @@ I.waitForResponse(response => response.url() === 'https://example.com' && respon
 
 #### Parameters
 
--   `urlOrPredicate` **([string][9] | [function][11])** 
--   `sec` **[number][10]?** number of seconds to wait 
+-   `urlOrPredicate` **([string][10] | [function][12])** 
+-   `sec` **[number][11]?** number of seconds to wait 
+
+Returns **[Promise][7]&lt;any>** 
 
 ### waitForText
 
@@ -1860,9 +1935,9 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 #### Parameters
 
--   `text` **[string][9]** to wait for.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
--   `context` **([string][9] | [object][7])?** (optional) element located by CSS|XPath|strict locator. 
+-   `text` **[string][10]** to wait for.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+-   `context` **([string][10] | [object][8])?** (optional) element located by CSS|XPath|strict locator. 
 
 ### waitForValue
 
@@ -1874,9 +1949,9 @@ I.waitForValue('//input', "GoodValue");
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** input field.
--   `value` **[string][9]** expected value.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `field` **([string][10] | [object][8])** input field.
+-   `value` **[string][10]** expected value.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForVisible
 
@@ -1889,8 +1964,8 @@ I.waitForVisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][26]. 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][26]. 
 
 ### waitInUrl
 
@@ -1902,8 +1977,8 @@ I.waitInUrl('/info', 2);
 
 #### Parameters
 
--   `urlPart` **[string][9]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][10]** value to check.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitNumberOfVisibleElements
 
@@ -1915,9 +1990,9 @@ I.waitNumberOfVisibleElements('a', 3);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitToHide
 
@@ -1930,8 +2005,17 @@ I.waitToHide('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+### waitUntilExists
+
+#### Parameters
+
+-   `locator`  
+-   `sec`  
+
+Returns **[Promise][7]&lt;void>** 
 
 ### waitUrlEquals
 
@@ -1944,8 +2028,8 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 #### Parameters
 
--   `urlPart` **[string][9]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][10]** value to check.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 [1]: https://github.com/microsoft/playwright
 
@@ -1959,17 +2043,17 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [6]: https://github.com/microsoft/playwright/blob/v0.11.0/docs/api.md#working-with-chrome-extensions
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[8]: https://jster.net/category/windows-modals-popups
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[9]: http://jster.net/category/windows-modals-popups
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -2024,7 +2024,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[7]: https://jster.net/category/windows-modals-popups
+[7]: http://jster.net/category/windows-modals-popups
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -2169,23 +2169,23 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 -   `urlPart` **[string][19]** value to check.
 -   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
 
-[1]: https://webdriver.io/
+[1]: http://webdriver.io/
 
 [2]: https://codecept.io/webdriver/#testing-with-webdriver
 
-[3]: https://codecept.io/acceptance/#smartwait
+[3]: http://codecept.io/acceptance/#smartwait
 
 [4]: https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
 
-[5]: https://webdriver.io/docs/timeouts.html
+[5]: http://webdriver.io/docs/timeouts.html
 
-[6]: https://webdriver.io/guide/getstarted/configuration.html
+[6]: http://webdriver.io/guide/getstarted/configuration.html
 
 [7]: https://seleniumhq.github.io/selenium/docs/api/rb/Selenium/WebDriver/IE/Options.html
 
 [8]: https://aerokube.com/selenoid/latest/
 
-[9]: https://webdriver.io/guide/usage/cloudservices.html
+[9]: http://webdriver.io/guide/usage/cloudservices.html
 
 [10]: https://webdriver.io/docs/sauce-service.html
 
@@ -2201,13 +2201,13 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [16]: https://github.com/PeterNgTr/codeceptjs-applitoolshelper
 
-[17]: https://webdriver.io/guide/usage/multiremote.html
+[17]: http://webdriver.io/guide/usage/multiremote.html
 
 [18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
 [19]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[20]: https://jster.net/category/windows-modals-popups
+[20]: http://jster.net/category/windows-modals-popups
 
 [21]: https://webdriver.io/docs/timeouts.html
 
@@ -2219,7 +2219,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[26]: https://webdriver.io/api/protocol/execute.html
+[26]: http://webdriver.io/api/protocol/execute.html
 
 [27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/webapi/executeAsyncScript.mustache
+++ b/docs/webapi/executeAsyncScript.mustache
@@ -21,4 +21,4 @@ let val = await I.executeAsyncScript(function(url, done) {
 
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
-@return {Promise<any>}
+@returns {Promise<any>}

--- a/docs/webapi/executeScript.mustache
+++ b/docs/webapi/executeScript.mustache
@@ -23,4 +23,4 @@ let date = await I.executeScript(function(el) {
 
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
-@return {Promise<any>}
+@returns {Promise<any>}

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -398,7 +398,7 @@ class Playwright extends Helper {
       const existingPages = await this.browserContext.pages();
       mainPage = existingPages[0] || await this.browserContext.newPage();
     }
-    targetCreatedHandler.call(this, mainPage);
+    await targetCreatedHandler.call(this, mainPage);
 
     await this._setPage(mainPage);
 
@@ -411,8 +411,10 @@ class Playwright extends Helper {
     if (!this.isRunning) return;
 
     if (this.isElectron) {
-      this.browser.close();
-      this.electronSessions.forEach(session => session.close());
+      await this.browser.close();
+      for (const session of this.electronSessions) {
+        await session.close();
+      }
       return;
     }
 
@@ -464,12 +466,12 @@ class Playwright extends Helper {
           page = await browserContext.newPage();
         }
 
-        targetCreatedHandler.call(this, page);
-        this._setPage(page);
+        await targetCreatedHandler.call(this, page);
+        await this._setPage(page);
         // Create a new page inside context.
         return browserContext;
       },
-      stop: async () => {
+      stop: () => {
         // is closed by _after
       },
       loadVars: async (context) => {
@@ -499,18 +501,19 @@ class Playwright extends Helper {
   * Use Playwright API inside a test.
   *
   * First argument is a description of an action.
-  * Second argument is async function that gets this helper as parameter.
+  * Second argument is function that gets this helper as parameter.
   *
   * { [`page`](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page), [`context`](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-context) [`browser`](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browser) } objects from Playwright API are available.
   *
   * ```js
-  * I.usePlaywrightTo('emulate offline mode', async ({ context }) {
+  * I.usePlaywrightTo('emulate offline mode', ({ context }) {
   *   await context.setOffline(true);
   * });
   * ```
   *
   * @param {string} description used to show in logs.
-  * @param {function} fn async functuion that executed with Playwright helper as argument
+  * @param {function} fn functuion that executed with Playwright helper as argument*
+  * @returns {Promise<any>}
   */
   usePlaywrightTo(description, fn) {
     return this._useTo(...arguments);
@@ -525,18 +528,22 @@ class Playwright extends Helper {
    * I.click('#triggerPopup');
    * I.acceptPopup();
    * ```
+   * @returns {Promise<void>}
    */
   amAcceptingPopups() {
     popupStore.actionType = 'accept';
+    return Promise.resolve();
   }
 
   /**
    * Accepts the active JavaScript native popup window, as created by window.alert|window.confirm|window.prompt.
    * Don't confuse popups with modal windows, as created by [various
    * libraries](http://jster.net/category/windows-modals-popups).
+   * @returns {Promise<void>}
    */
   acceptPopup() {
     popupStore.assertPopupActionType('accept');
+    return Promise.resolve();
   }
 
   /**
@@ -548,16 +555,20 @@ class Playwright extends Helper {
    * I.click('#triggerPopup');
    * I.cancelPopup();
    * ```
+   * @returns {Promise<void>}
    */
   amCancellingPopups() {
     popupStore.actionType = 'cancel';
+    return Promise.resolve();
   }
 
   /**
    * Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
+   * @returns {Promise<void>}
    */
   cancelPopup() {
     popupStore.assertPopupActionType('cancel');
+    return Promise.resolve();
   }
 
   /**
@@ -567,14 +578,15 @@ class Playwright extends Helper {
     popupStore.assertPopupVisible();
     const popupText = await popupStore.popup.message();
     stringIncludes('text in popup').assert(text, popupText);
+    return Promise.resolve();
   }
 
   /**
    * Set current page
    * @param {object} page page to set
+   * @returns {Promise<void>}
    */
   async _setPage(page) {
-    page = await page;
     this._addPopupListener(page);
     this.page = page;
     if (!page) return;
@@ -584,7 +596,7 @@ class Playwright extends Helper {
       console.log('ERROR: Page has crashed, closing page!');
       await page.close();
     });
-    this.context = await this.page;
+    this.context = this.page;
     this.contextLocator = null;
     if (this.options.browser === 'chrome') {
       await page.bringToFront();
@@ -597,35 +609,37 @@ class Playwright extends Helper {
    *
    * The popup listener handles the dialog with the predefined action when it appears on the page.
    * It also saves a reference to the object which is used in seeInPopup.
+   * @returns {Promise<void>}
    */
   _addPopupListener(page) {
-    if (!page) {
-      return;
-    }
-    page.removeAllListeners('dialog');
-    page.on('dialog', async (dialog) => {
-      popupStore.popup = dialog;
-      const action = popupStore.actionType || this.options.defaultPopupAction;
-      await this._waitForAction();
+    if (page) {
+      page.removeAllListeners('dialog');
+      page.on('dialog', async (dialog) => {
+        popupStore.popup = dialog;
+        const action = popupStore.actionType || this.options.defaultPopupAction;
+        await this._waitForAction();
 
-      switch (action) {
-        case 'accept':
-          return dialog.accept();
+        switch (action) {
+          case 'accept':
+            return dialog.accept();
 
-        case 'cancel':
-          return dialog.dismiss();
+          case 'cancel':
+            return dialog.dismiss();
 
-        default: {
-          throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted');
+          default: {
+            throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted');
+          }
         }
-      }
-    });
+      });
+    }
+    return Promise.resolve();
   }
 
   /**
    * Gets page URL including hash.
+   * @returns {Promise<any>}
    */
-  async _getPageUrl() {
+  _getPageUrl() {
     return this.executeScript(() => window.location.href);
   }
 
@@ -637,13 +651,16 @@ class Playwright extends Helper {
    * ```
    * @return {Promise<string | null>}
    */
-  async grabPopupText() {
+  grabPopupText() {
     if (popupStore.popup) {
       return popupStore.popup.message();
     }
-    return null;
+    return Promise.resolve(null);
   }
 
+  /**
+   * @returns {Promise<void>}
+   */
   async _startBrowser() {
     if (this.isElectron) {
       this.browser = await playwright._electron.launch(this.playwrightOptions);
@@ -670,21 +687,31 @@ class Playwright extends Helper {
     this.isRunning = true;
   }
 
+  /**
+   * @returns {Promise<void>}
+   */
   _getType() {
     return this.browser._type;
   }
 
+  /**
+   * @returns {Promise<void>}
+   */
   async _stopBrowser() {
     this.withinLocator = null;
-    this._setPage(null);
+    await this._setPage(null);
     this.context = null;
     popupStore.clear();
 
     await this.browser.close();
   }
 
-  async _evaluateHandeInContext(...args) {
-    const context = await this._getContext();
+  /**
+   * @param args
+   * @returns {Promise<any>}
+   */
+  _evaluateHandeInContext(...args) {
+    const context = this._getContext();
     return context.evaluateHandle(...args);
   }
 
@@ -713,9 +740,9 @@ class Playwright extends Helper {
     this.withinLocator = new Locator(locator);
   }
 
-  async _withinEnd() {
+  _withinEnd() {
     this.withinLocator = null;
-    this.context = await this.page;
+    this.context = this.page;
     this.contextLocator = null;
   }
 
@@ -797,8 +824,9 @@ class Playwright extends Helper {
    * ```
    *
    * @param {object} customHeaders headers to set
+   * @returns {Promise<any>}
    */
-  async haveRequestHeaders(customHeaders) {
+  haveRequestHeaders(customHeaders) {
     if (!customHeaders) {
       throw new Error('Cannot send empty headers.');
     }
@@ -822,14 +850,14 @@ class Playwright extends Helper {
   /**
    * {{> dragAndDrop }}
    */
-  async dragAndDrop(srcElement, destElement) {
+  dragAndDrop(srcElement, destElement) {
     return proceedDragAndDrop.call(this, srcElement, destElement);
   }
 
   /**
    * {{> refreshPage }}
    */
-  async refreshPage() {
+  refreshPage() {
     return this.page.reload({ timeout: this.options.getPageTimeout, waitUntil: this.options.waitForNavigation });
   }
 
@@ -889,7 +917,7 @@ class Playwright extends Helper {
   /**
    * {{> grabPageScrollPosition }}
    */
-  async grabPageScrollPosition() {
+  grabPageScrollPosition() {
     /* eslint-disable comma-dangle */
     function getScrollPosition() {
       return {
@@ -920,7 +948,7 @@ class Playwright extends Helper {
   /**
    * {{> grabTitle }}
    */
-  async grabTitle() {
+  grabTitle() {
     return this.page.title();
   }
 
@@ -931,11 +959,10 @@ class Playwright extends Helper {
    * ```js
    * const elements = await this.helpers['Playwright']._locate({name: 'password'});
    * ```
-   *
-   *
+   * @returns {Promise<any>}
    */
-  async _locate(locator) {
-    const context = await this.context || await this._getContext();
+  _locate(locator) {
+    const context = this.context || this._getContext();
     return findElements(context, locator);
   }
 
@@ -946,9 +973,10 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateCheckable('I agree with terms and conditions').then // ...
    * ```
+   * @returns {Promise<any>}
    */
   async _locateCheckable(locator, providedContext = null) {
-    const context = providedContext || await this._getContext();
+    const context = providedContext || this._getContext();
     const els = await findCheckable.call(this, locator, context);
     assertElementExists(els[0], locator, 'Checkbox or radio');
     return els[0];
@@ -960,9 +988,10 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateClickable('Next page').then // ...
    * ```
+   * @returns {Promise<any>}
    */
-  async _locateClickable(locator) {
-    const context = await this._getContext();
+  _locateClickable(locator) {
+    const context = this._getContext();
     return findClickable.call(this, context, locator);
   }
 
@@ -972,8 +1001,9 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateFields('Your email').then // ...
    * ```
+   * @returns {Promise<any>}
    */
-  async _locateFields(locator) {
+  _locateFields(locator) {
     return findFields.call(this, locator);
   }
 
@@ -986,6 +1016,7 @@ class Playwright extends Helper {
    * ```
    *
    * @param {number} [num=1]
+   * @returns {Promise<void>}
    */
   async switchToNextTab(num = 1) {
     if (this.isElectron) {
@@ -1012,6 +1043,7 @@ class Playwright extends Helper {
    * I.switchToPreviousTab(2);
    * ```
    * @param {number} [num=1]
+   * @returns {Promise<void>}
    */
   async switchToPreviousTab(num = 1) {
     if (this.isElectron) {
@@ -1036,6 +1068,7 @@ class Playwright extends Helper {
    * ```js
    * I.closeCurrentTab();
    * ```
+   * @returns {Promise<void>}
    */
   async closeCurrentTab() {
     if (this.isElectron) {
@@ -1053,6 +1086,7 @@ class Playwright extends Helper {
    * ```js
    * I.closeOtherTabs();
    * ```
+   * @returns {Promise<void>}
    */
   async closeOtherTabs() {
     const pages = await this.browserContext.pages();
@@ -1077,6 +1111,7 @@ class Playwright extends Helper {
    * // enable mobile
    * I.openNewTab({ isMobile: true });
    * ```
+   * @returns {Promise<void>}
    */
   async openNewTab(options) {
     if (this.isElectron) {
@@ -1145,6 +1180,7 @@ class Playwright extends Helper {
    * ```
    *
    * @param {string} [fileName] set filename for downloaded file
+   * @returns {Promise<void>}
    */
   async handleDownloads(fileName = 'downloads') {
     this.page.waitForEvent('download').then(async (download) => {
@@ -1165,14 +1201,15 @@ class Playwright extends Helper {
    *
    *
    */
-  async click(locator, context = null) {
+  click(locator, context = null) {
     return proceedClick.call(this, locator, context);
   }
 
   /**
    * Clicks link and waits for navigation (deprecated)
+   * @returns {Promise<void>}
    */
-  async clickLink(locator, context = null) {
+  clickLink(locator, context = null) {
     console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.');
     console.log('Replace I.clickLink with I.click');
     return this.click(locator, context);
@@ -1181,7 +1218,7 @@ class Playwright extends Helper {
   /**
    * {{> forceClick }}
    */
-  async forceClick(locator, context = null) {
+  forceClick(locator, context = null) {
     return proceedClick.call(this, locator, context, { force: true });
   }
 
@@ -1190,7 +1227,7 @@ class Playwright extends Helper {
    *
    *
    */
-  async doubleClick(locator, context = null) {
+  doubleClick(locator, context = null) {
     return proceedClick.call(this, locator, context, { clickCount: 2 });
   }
 
@@ -1199,7 +1236,7 @@ class Playwright extends Helper {
    *
    *
    */
-  async rightClick(locator, context = null) {
+  rightClick(locator, context = null) {
     return proceedClick.call(this, locator, context, { button: 'right' });
   }
 
@@ -1234,14 +1271,14 @@ class Playwright extends Helper {
   /**
    * {{> seeCheckboxIsChecked }}
    */
-  async seeCheckboxIsChecked(field) {
+  seeCheckboxIsChecked(field) {
     return proceedIsChecked.call(this, 'assert', field);
   }
 
   /**
    * {{> dontSeeCheckboxIsChecked }}
    */
-  async dontSeeCheckboxIsChecked(field) {
+  dontSeeCheckboxIsChecked(field) {
     return proceedIsChecked.call(this, 'negate', field);
   }
 
@@ -1329,7 +1366,7 @@ class Playwright extends Helper {
   /**
    * {{> clearField }}
    */
-  async clearField(field) {
+  clearField(field) {
     return this.fillField(field, '');
   }
 
@@ -1349,14 +1386,14 @@ class Playwright extends Helper {
   /**
    * {{> seeInField }}
    */
-  async seeInField(field, value) {
+  seeInField(field, value) {
     return proceedSeeInField.call(this, 'assert', field, value);
   }
 
   /**
    * {{> dontSeeInField }}
    */
-  async dontSeeInField(field, value) {
+  dontSeeInField(field, value) {
     return proceedSeeInField.call(this, 'negate', field, value);
   }
 
@@ -1441,7 +1478,7 @@ class Playwright extends Helper {
 
   /**
    * {{> dontSeeCurrentUrlEquals }}
-   */
+   async  */
   async dontSeeCurrentUrlEquals(url) {
     urlEquals(this.options.url).negate(url, await this._getPageUrl());
   }
@@ -1451,14 +1488,14 @@ class Playwright extends Helper {
    *
    *
    */
-  async see(text, context = null) {
+  see(text, context = null) {
     return proceedSee.call(this, 'assert', text, context);
   }
 
   /**
    * {{> seeTextEquals }}
    */
-  async seeTextEquals(text, context = null) {
+  seeTextEquals(text, context = null) {
     return proceedSee.call(this, 'assert', text, context, true);
   }
 
@@ -1467,14 +1504,14 @@ class Playwright extends Helper {
    *
    *
    */
-  async dontSee(text, context = null) {
+  dontSee(text, context = null) {
     return proceedSee.call(this, 'negate', text, context);
   }
 
   /**
    * {{> grabSource }}
    */
-  async grabSource() {
+  grabSource() {
     return this.page.content();
   }
 
@@ -1487,7 +1524,7 @@ class Playwright extends Helper {
    * ```
    * @return {Promise<any[]>}
    */
-  async grabBrowserLogs() {
+  grabBrowserLogs() {
     const logs = consoleLogStore.entries;
     consoleLogStore.clear();
     return logs;
@@ -1496,7 +1533,7 @@ class Playwright extends Helper {
   /**
    * {{> grabCurrentUrl }}
    */
-  async grabCurrentUrl() {
+  grabCurrentUrl() {
     return this._getPageUrl();
   }
 
@@ -1539,7 +1576,7 @@ class Playwright extends Helper {
   /**
    * {{> setCookie }}
    */
-  async setCookie(cookie) {
+  setCookie(cookie) {
     if (Array.isArray(cookie)) {
       return this.browserContext.addCookies(cookie);
     }
@@ -1578,7 +1615,7 @@ class Playwright extends Helper {
   /**
    * {{> clearCookie }}
    */
-  async clearCookie() {
+  clearCookie() {
     // Playwright currently doesn't support to delete a certain cookie
     // https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browsercontext
     if (!this.browserContext) return;
@@ -1609,7 +1646,7 @@ class Playwright extends Helper {
    * @param {any} [arg] optional argument to pass to the function
    * @return {Promise<any>}
    */
-  async executeScript(fn, arg) {
+  executeScript(fn, arg) {
     let context = this.page;
     if (this.context && this.context.constructor.name === 'Frame') {
       context = this.context; // switching to iframe context
@@ -1855,7 +1892,7 @@ class Playwright extends Helper {
   /**
    * {{> saveScreenshot }}
    */
-  async saveScreenshot(fileName, fullPage) {
+  saveScreenshot(fileName, fullPage) {
     const fullPageOption = fullPage || this.options.fullPageScreenshots;
     const outputFile = screenshotOutputFolder(fileName);
 
@@ -1917,7 +1954,7 @@ class Playwright extends Helper {
   /**
    * {{> wait }}
    */
-  async wait(sec) {
+  wait(sec) {
     return new Promise(((done) => {
       setTimeout(done, sec * 1000);
     }));
@@ -1926,12 +1963,12 @@ class Playwright extends Helper {
   /**
    * {{> waitForEnabled }}
    */
-  async waitForEnabled(locator, sec) {
+  waitForEnabled(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    const matcher = await this.context;
+    const matcher = this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (!locator.isXPath()) {
       const valueFn = function ([locator]) {
         return Array.from(document.querySelectorAll(locator)).filter(el => !el.disabled).length > 0;
@@ -1952,12 +1989,12 @@ class Playwright extends Helper {
   /**
    * {{> waitForValue }}
    */
-  async waitForValue(field, value, sec) {
+  waitForValue(field, value, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     const locator = new Locator(field, 'css');
-    const matcher = await this.context;
+    const matcher = this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (!locator.isXPath()) {
       const valueFn = function ([locator, value]) {
         return Array.from(document.querySelectorAll(locator)).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
@@ -1980,12 +2017,11 @@ class Playwright extends Helper {
    * {{> waitNumberOfVisibleElements }}
    *
    */
-  async waitNumberOfVisibleElements(locator, num, sec) {
+  waitNumberOfVisibleElements(locator, num, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       const visibleFn = function ([locator, num]) {
         const els = document.querySelectorAll(locator);
@@ -2010,7 +2046,7 @@ class Playwright extends Helper {
   /**
    * {{> waitForClickable }}
    */
-  async waitForClickable(locator, waitTimeout) {
+  waitForClickable(locator, waitTimeout) {
     console.log('I.waitForClickable is DEPRECATED: This is no longer needed, Playwright automatically waits for element to be clickable');
     console.log('Remove usage of this function');
   }
@@ -2019,11 +2055,11 @@ class Playwright extends Helper {
    * {{> waitForElement }}
    *
    */
-  async waitForElement(locator, sec) {
+  waitForElement(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
 
-    const context = await this._getContext();
+    const context = this._getContext();
     const waiter = context.waitForSelector(buildLocatorString(locator), { timeout: waitTimeout, state: 'attached' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${err.message}`);
@@ -2035,10 +2071,10 @@ class Playwright extends Helper {
    *
    * This method accepts [React selectors](https://codecept.io/react).
    */
-  async waitForVisible(locator, sec) {
+  waitForVisible(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    const context = await this._getContext();
+    const context = this._getContext();
     const waiter = context.waitForSelector(buildLocatorString(locator), { timeout: waitTimeout, state: 'visible' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`);
@@ -2048,10 +2084,10 @@ class Playwright extends Helper {
   /**
    * {{> waitForInvisible }}
    */
-  async waitForInvisible(locator, sec) {
+  waitForInvisible(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    const context = await this._getContext();
+    const context = this._getContext();
     const waiter = context.waitForSelector(buildLocatorString(locator), { timeout: waitTimeout, state: 'hidden' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`);
@@ -2061,16 +2097,16 @@ class Playwright extends Helper {
   /**
    * {{> waitToHide }}
    */
-  async waitToHide(locator, sec) {
+  waitToHide(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    const context = await this._getContext();
+    const context = this._getContext();
     return context.waitForSelector(buildLocatorString(locator), { timeout: waitTimeout, state: 'hidden' }).catch((err) => {
       throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
     });
   }
 
-  async _getContext() {
+  _getContext() {
     if (this.context && this.context.constructor.name === 'Frame') {
       return this.context;
     }
@@ -2080,7 +2116,7 @@ class Playwright extends Helper {
   /**
    * {{> waitInUrl }}
    */
-  async waitInUrl(urlPart, sec = null) {
+  waitInUrl(urlPart, sec = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
     return this.page.waitForFunction((urlPart) => {
@@ -2099,7 +2135,7 @@ class Playwright extends Helper {
   /**
    * {{> waitUrlEquals }}
    */
-  async waitUrlEquals(urlPart, sec = null) {
+  waitUrlEquals(urlPart, sec = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
     const baseUrl = this.options.url;
@@ -2123,11 +2159,11 @@ class Playwright extends Helper {
   /**
    * {{> waitForText }}
    */
-  async waitForText(text, sec = null, context = null) {
+  waitForText(text, sec = null, context = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     let waiter;
 
-    const contextObject = await this._getContext();
+    const contextObject = this._getContext();
 
     if (context) {
       const locator = new Locator(context, 'css');
@@ -2161,8 +2197,9 @@ class Playwright extends Helper {
    *
    * @param {string|function} urlOrPredicate
    * @param {?number} [sec=null] seconds to wait
+   * @returns {Promise<any>}
    */
-  async waitForRequest(urlOrPredicate, sec = null) {
+  waitForRequest(urlOrPredicate, sec = null) {
     const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
     return this.page.waitForRequest(urlOrPredicate, { timeout });
   }
@@ -2177,8 +2214,9 @@ class Playwright extends Helper {
    *
    * @param {string|function} urlOrPredicate
    * @param {?number} [sec=null] number of seconds to wait
+   * @returns {Promise<any>}
    */
-  async waitForResponse(urlOrPredicate, sec = null) {
+  waitForResponse(urlOrPredicate, sec = null) {
     const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
     return this.page.waitForResponse(urlOrPredicate, { timeout });
   }
@@ -2228,7 +2266,7 @@ class Playwright extends Helper {
   /**
    * {{> waitForFunction }}
    */
-  async waitForFunction(fn, argsOrSec = null, sec = null) {
+  waitForFunction(fn, argsOrSec = null, sec = null) {
     let args = [];
     if (argsOrSec) {
       if (Array.isArray(argsOrSec)) {
@@ -2238,7 +2276,7 @@ class Playwright extends Helper {
       }
     }
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const context = await this._getContext();
+    const context = this._getContext();
     return context.waitForFunction(fn, args, { timeout: waitTimeout });
   }
 
@@ -2248,8 +2286,9 @@ class Playwright extends Helper {
    * See [Playwright's reference](https://playwright.dev/docs/api/class-page?_highlight=waitfornavi#pagewaitfornavigationoptions)
    *
    * @param {*} opts
+   * @returns {Promise<any>}
    */
-  async waitForNavigation(opts = {}) {
+  waitForNavigation(opts = {}) {
     opts = {
       timeout: this.options.getPageTimeout,
       waitUntil: this.options.waitForNavigation,
@@ -2258,7 +2297,12 @@ class Playwright extends Helper {
     return this.page.waitForNavigation(opts);
   }
 
-  async waitUntilExists(locator, sec) {
+  /**
+   * @param locator
+   * @param sec
+   * @returns {Promise<void>}
+   */
+  waitUntilExists(locator, sec) {
     console.log(`waitUntilExists deprecated:
     * use 'waitForElement' to wait for element to be attached
     * use 'waitForDetached to wait for element to be removed'`);
@@ -2268,12 +2312,12 @@ class Playwright extends Helper {
   /**
    * {{> waitForDetached }}
    */
-  async waitForDetached(locator, sec) {
+  waitForDetached(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
 
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (!locator.isXPath()) {
       waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'detached' });
     } else {
@@ -2288,14 +2332,17 @@ class Playwright extends Helper {
     });
   }
 
-  async _waitForAction() {
+  /**
+   * @returns {Promise<void>}
+   */
+  _waitForAction() {
     return this.wait(this.options.waitForAction / 1000);
   }
 
   /**
    * {{> grabDataFromPerformanceTiming }}
    */
-  async grabDataFromPerformanceTiming() {
+  grabDataFromPerformanceTiming() {
     return perfTiming;
   }
 
@@ -2321,8 +2368,9 @@ class Playwright extends Helper {
   * @param {string} [url] URL, regex or pattern for to match URL
   * @param {function} [handler] a function to process request
   *
+  * @returns {Promise<any>}
   */
-  async mockRoute(url, handler) {
+  mockRoute(url, handler) {
     return this.browserContext.route(...arguments);
   }
 
@@ -2338,8 +2386,9 @@ class Playwright extends Helper {
   * @param {string} [url] URL, regex or pattern for to match URL
   * @param {function} [handler] a function to process request
   *
+  * @returns {Promise<any>}
   */
-  async stopMockingRoute(url, handler) {
+  stopMockingRoute(url, handler) {
     return this.browserContext.unroute(...arguments);
   }
 }
@@ -2356,7 +2405,7 @@ function buildLocatorString(locator) {
   return locator.simplify();
 }
 
-async function findElements(matcher, locator) {
+function findElements(matcher, locator) {
   if (locator.react) return findReact(matcher, locator);
   locator = new Locator(locator, 'css');
   return matcher.$$(buildLocatorString(locator));
@@ -2376,7 +2425,7 @@ async function getVisibleElements(elements) {
 }
 
 async function proceedClick(locator, context = null, options = {}) {
-  let matcher = await this._getContext();
+  let matcher = this._getContext();
   if (context) {
     const els = await this._locate(context);
     assertElementExists(els, context);
@@ -2434,7 +2483,7 @@ async function proceedSee(assertType, text, context, strict = false) {
   let description;
   let allText;
   if (!context) {
-    let el = await this.context;
+    let el = this.context;
 
     if (el && !el.getProperty) {
       // Fallback to body
@@ -2458,7 +2507,7 @@ async function proceedSee(assertType, text, context, strict = false) {
 }
 
 async function findCheckable(locator, context) {
-  let contextEl = await this.context;
+  let contextEl = this.context;
   if (typeof context === 'string') {
     contextEl = await findElements.call(this, contextEl, (new Locator(context, 'css')).simplify());
     contextEl = contextEl[0];

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -710,7 +710,7 @@ class Playwright extends Helper {
    * @param args
    * @returns {Promise<any>}
    */
-  _evaluateHandeInContext(...args) {
+  _evaluateHandleInContext(...args) {
     const context = this._getContext();
     return context.evaluateHandle(...args);
   }
@@ -1355,9 +1355,9 @@ class Playwright extends Helper {
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue());
     if (tag === 'INPUT' || tag === 'TEXTAREA') {
-      await this._evaluateHandeInContext(el => el.value = '', el);
+      await this._evaluateHandleInContext(el => el.value = '', el);
     } else if (editable) {
-      await this._evaluateHandeInContext(el => el.innerHTML = '', el);
+      await this._evaluateHandleInContext(el => el.innerHTML = '', el);
     }
     await el.type(value.toString(), { delay: this.options.pressKeyDelay });
     return this._waitForAction();
@@ -1429,15 +1429,15 @@ class Playwright extends Helper {
       const opt = xpathLocator.literal(option[key]);
       let optEl = await findElements.call(this, el, { xpath: Locator.select.byVisibleText(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._evaluateHandleInContext(el => el.selected = true, optEl[0]);
         continue;
       }
       optEl = await findElements.call(this, el, { xpath: Locator.select.byValue(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._evaluateHandleInContext(el => el.selected = true, optEl[0]);
       }
     }
-    await this._evaluateHandeInContext((element) => {
+    await this._evaluateHandleInContext((element) => {
       element.dispatchEvent(new Event('input', { bubbles: true }));
       element.dispatchEvent(new Event('change', { bubbles: true }));
     }, el);
@@ -1867,7 +1867,7 @@ class Playwright extends Helper {
     const array = [];
 
     for (let index = 0; index < els.length; index++) {
-      const a = await this._evaluateHandeInContext(([el, attr]) => el[attr] || el.getAttribute(attr), [els[index], attr]);
+      const a = await this._evaluateHandleInContext(([el, attr]) => el[attr] || el.getAttribute(attr), [els[index], attr]);
       array.push(await a.jsonValue());
     }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -560,7 +560,7 @@ class Puppeteer extends Helper {
     }
   }
 
-  async _evaluateHandeInContext(...args) {
+  async _evaluateHandleInContext(...args) {
     let context = await this._getContext();
 
     if (context.constructor.name === 'Frame') {
@@ -1262,9 +1262,9 @@ class Puppeteer extends Helper {
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue());
     if (tag === 'INPUT' || tag === 'TEXTAREA') {
-      await this._evaluateHandeInContext(el => el.value = '', el);
+      await this._evaluateHandleInContext(el => el.value = '', el);
     } else if (editable) {
-      await this._evaluateHandeInContext(el => el.innerHTML = '', el);
+      await this._evaluateHandleInContext(el => el.innerHTML = '', el);
     }
     await el.type(value.toString(), { delay: this.options.pressKeyDelay });
     return this._waitForAction();
@@ -1337,15 +1337,15 @@ class Puppeteer extends Helper {
       const opt = xpathLocator.literal(option[key]);
       let optEl = await findElements.call(this, el, { xpath: Locator.select.byVisibleText(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._evaluateHandleInContext(el => el.selected = true, optEl[0]);
         continue;
       }
       optEl = await findElements.call(this, el, { xpath: Locator.select.byValue(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._evaluateHandleInContext(el => el.selected = true, optEl[0]);
       }
     }
-    await this._evaluateHandeInContext((element) => {
+    await this._evaluateHandleInContext((element) => {
       element.dispatchEvent(new Event('input', { bubbles: true }));
       element.dispatchEvent(new Event('change', { bubbles: true }));
     }, el);
@@ -1769,7 +1769,7 @@ class Puppeteer extends Helper {
     const els = await this._locate(locator);
     const array = [];
     for (let index = 0; index < els.length; index++) {
-      const a = await this._evaluateHandeInContext((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
+      const a = await this._evaluateHandleInContext((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
       array.push(await a.jsonValue());
     }
     return array;

--- a/runok.js
+++ b/runok.js
@@ -153,7 +153,8 @@ Our community prepared some valuable recipes for setting up CI systems with Code
       copy(`lib/helper/${file}`, `docs/build/${file}`);
       replaceInFile(`docs/build/${file}`, (cfg) => {
         for (const i in placeholders) {
-          cfg.replace(placeholders[i], templates[i]);
+          const template = templates[i] + (templates[i].includes('@return') ? '' : '\n@returns {Promise<void>} nothing\n');
+          cfg.replace(placeholders[i], template);
         }
         if (!forTypings) {
           cfg.replace(/CodeceptJS.LocatorOrString\?/g, '(string | object)?');

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -4,10 +4,10 @@ const str = 'text';
 const num = 1;
 
 wd.amOnPage(); // $ExpectError
-wd.amOnPage(''); // $ExpectType void
+wd.amOnPage(''); // $ExpectType Promise<void>
 
 wd.click(); // $ExpectError
-wd.click('div'); // $ExpectType void
+wd.click('div'); // $ExpectType Promise<void>
 wd.click({ css: 'div' });
 wd.click({ xpath: '//div' });
 wd.click({ name: 'div' });
@@ -25,7 +25,7 @@ wd.click('div', { android: '//div' });
 wd.click('div', { ios: '//div' });
 
 wd.forceClick(); // $ExpectError
-wd.forceClick('div'); // $ExpectType void
+wd.forceClick('div'); // $ExpectType Promise<void>
 wd.forceClick({ css: 'div' });
 wd.forceClick({ xpath: '//div' });
 wd.forceClick({ name: 'div' });
@@ -43,7 +43,7 @@ wd.forceClick('div', { android: '//div' });
 wd.forceClick('div', { ios: '//div' });
 
 wd.doubleClick(); // $ExpectError
-wd.doubleClick('div'); // $ExpectType void
+wd.doubleClick('div'); // $ExpectType Promise<void>
 wd.doubleClick({ css: 'div' });
 wd.doubleClick({ xpath: '//div' });
 wd.doubleClick({ name: 'div' });
@@ -61,7 +61,7 @@ wd.doubleClick('div', { android: '//div' });
 wd.doubleClick('div', { ios: '//div' });
 
 wd.rightClick(); // $ExpectError
-wd.rightClick('div'); // $ExpectType void
+wd.rightClick('div'); // $ExpectType Promise<void>
 wd.rightClick({ css: 'div' });
 wd.rightClick({ xpath: '//div' });
 wd.rightClick({ name: 'div' });
@@ -80,7 +80,7 @@ wd.rightClick('div', { ios: '//div' });
 
 wd.fillField(); // $ExpectError
 wd.fillField('div'); // $ExpectError
-wd.fillField('div', str); // $ExpectType void
+wd.fillField('div', str); // $ExpectType Promise<void>
 wd.fillField({ css: 'div' }, str);
 wd.fillField({ xpath: '//div' }, str);
 wd.fillField({ name: 'div' }, str);
@@ -91,7 +91,7 @@ wd.fillField(locate('div'), str);
 
 wd.appendField(); // $ExpectError
 wd.appendField('div'); // $ExpectError
-wd.appendField('div', str); // $ExpectType void
+wd.appendField('div', str); // $ExpectType Promise<void>
 wd.appendField({ css: 'div' }, str);
 wd.appendField({ xpath: '//div' }, str);
 wd.appendField({ name: 'div' }, str);
@@ -111,98 +111,98 @@ wd.clearField({ ios: 'div' });
 
 wd.selectOption(); // $ExpectError
 wd.selectOption('div'); // $ExpectError
-wd.selectOption('div', str); // $ExpectType void
+wd.selectOption('div', str); // $ExpectType Promise<void>
 
 wd.attachFile(); // $ExpectError
 wd.attachFile('div'); // $ExpectError
-wd.attachFile('div', str); // $ExpectType void
+wd.attachFile('div', str); // $ExpectType Promise<void>
 
 wd.checkOption(); // $ExpectError
-wd.checkOption('div'); // $ExpectType void
+wd.checkOption('div'); // $ExpectType Promise<void>
 
 wd.uncheckOption(); // $ExpectError
-wd.uncheckOption('div'); // $ExpectType void
+wd.uncheckOption('div'); // $ExpectType Promise<void>
 
 wd.seeInTitle(); // $ExpectError
-wd.seeInTitle(str); // $ExpectType void
+wd.seeInTitle(str); // $ExpectType Promise<void>
 
 wd.seeTitleEquals(); // $ExpectError
-wd.seeTitleEquals(str); // $ExpectType void
+wd.seeTitleEquals(str); // $ExpectType Promise<void>
 
 wd.dontSeeInTitle(); // $ExpectError
-wd.dontSeeInTitle(str); // $ExpectType void
+wd.dontSeeInTitle(str); // $ExpectType Promise<void>
 
 wd.see(); // $ExpectError
-wd.see(str); // $ExpectType void
-wd.see(str, 'div'); // $ExpectType void
+wd.see(str); // $ExpectType Promise<void>
+wd.see(str, 'div'); // $ExpectType Promise<void>
 
 wd.dontSee(); // $ExpectError
-wd.dontSee(str); // $ExpectType void
-wd.dontSee(str, 'div'); // $ExpectType void
+wd.dontSee(str); // $ExpectType Promise<void>
+wd.dontSee(str, 'div'); // $ExpectType Promise<void>
 
 wd.seeTextEquals(); // $ExpectError
-wd.seeTextEquals(str); // $ExpectType void
-wd.seeTextEquals(str, 'div'); // $ExpectType void
+wd.seeTextEquals(str); // $ExpectType Promise<void>
+wd.seeTextEquals(str, 'div'); // $ExpectType Promise<void>
 
 wd.seeInField(); // $ExpectError
 wd.seeInField('div'); // $ExpectError
-wd.seeInField('div', str); // $ExpectType void
+wd.seeInField('div', str); // $ExpectType Promise<void>
 
 wd.dontSeeInField(); // $ExpectError
 wd.dontSeeInField('div'); // $ExpectError
-wd.dontSeeInField('div', str); // $ExpectType void
+wd.dontSeeInField('div', str); // $ExpectType Promise<void>
 
 wd.seeCheckboxIsChecked(); // $ExpectError
-wd.seeCheckboxIsChecked('div'); // $ExpectType void
+wd.seeCheckboxIsChecked('div'); // $ExpectType Promise<void>
 
 wd.dontSeeCheckboxIsChecked(); // $ExpectError
-wd.dontSeeCheckboxIsChecked('div'); // $ExpectType void
+wd.dontSeeCheckboxIsChecked('div'); // $ExpectType Promise<void>
 
 wd.seeElement(); // $ExpectError
-wd.seeElement('div'); // $ExpectType void
+wd.seeElement('div'); // $ExpectType Promise<void>
 
 wd.dontSeeElement(); // $ExpectError
-wd.dontSeeElement('div'); // $ExpectType void
+wd.dontSeeElement('div'); // $ExpectType Promise<void>
 
 wd.seeElementInDOM(); // $ExpectError
-wd.seeElementInDOM('div'); // $ExpectType void
+wd.seeElementInDOM('div'); // $ExpectType Promise<void>
 
 wd.dontSeeElementInDOM(); // $ExpectError
-wd.dontSeeElementInDOM('div'); // $ExpectType void
+wd.dontSeeElementInDOM('div'); // $ExpectType Promise<void>
 
 wd.seeInSource(); // $ExpectError
-wd.seeInSource(str); // $ExpectType void
+wd.seeInSource(str); // $ExpectType Promise<void>
 
 wd.dontSeeInSource(); // $ExpectError
-wd.dontSeeInSource(str); // $ExpectType void
+wd.dontSeeInSource(str); // $ExpectType Promise<void>
 
 wd.seeNumberOfElements(); // $ExpectError
 wd.seeNumberOfElements('div'); // $ExpectError
-wd.seeNumberOfElements('div', num); // $ExpectType void
+wd.seeNumberOfElements('div', num); // $ExpectType Promise<void>
 
 wd.seeNumberOfVisibleElements(); // $ExpectError
 wd.seeNumberOfVisibleElements('div'); // $ExpectError
-wd.seeNumberOfVisibleElements('div', num); // $ExpectType void
+wd.seeNumberOfVisibleElements('div', num); // $ExpectType Promise<void>
 
 wd.seeCssPropertiesOnElements(); // $ExpectError
 wd.seeCssPropertiesOnElements('div'); // $ExpectError
-wd.seeCssPropertiesOnElements('div', str); // $ExpectType void
+wd.seeCssPropertiesOnElements('div', str); // $ExpectType Promise<void>
 
 wd.seeAttributesOnElements(); // $ExpectError
 wd.seeAttributesOnElements('div'); // $ExpectError
-wd.seeAttributesOnElements('div', str); // $ExpectType void
+wd.seeAttributesOnElements('div', str); // $ExpectType Promise<void>
 
 wd.seeInCurrentUrl(); // $ExpectError
-wd.seeInCurrentUrl(str); // $ExpectType void
+wd.seeInCurrentUrl(str); // $ExpectType Promise<void>
 
 wd.seeCurrentUrlEquals(); // $ExpectError
-wd.seeCurrentUrlEquals(str); // $ExpectType void
+wd.seeCurrentUrlEquals(str); // $ExpectType Promise<void>
 
 wd.dontSeeInCurrentUrl(); // $ExpectError
-wd.dontSeeInCurrentUrl(str); // $ExpectType void
+wd.dontSeeInCurrentUrl(str); // $ExpectType Promise<void>
 
 wd.dontSeeCurrentUrlEquals(); // $ExpectError
-wd.dontSeeCurrentUrlEquals(str); // $ExpectType void
+wd.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<void>
 
 wd.executeScript(); // $ExpectError
 wd.executeScript(str); // $ExpectType Promise<any>
@@ -219,26 +219,26 @@ wd.scrollIntoView('div'); // $ExpectError
 wd.scrollIntoView('div', { behavior: 'auto', block: 'center', inline: 'center' });
 
 wd.scrollTo(); // $ExpectError
-wd.scrollTo('div'); // $ExpectType void
-wd.scrollTo('div', num, num); // $ExpectType void
+wd.scrollTo('div'); // $ExpectType Promise<void>
+wd.scrollTo('div', num, num); // $ExpectType Promise<void>
 
 wd.moveCursorTo(); // $ExpectError
-wd.moveCursorTo('div'); // $ExpectType void
-wd.moveCursorTo('div', num, num); // $ExpectType void
+wd.moveCursorTo('div'); // $ExpectType Promise<void>
+wd.moveCursorTo('div', num, num); // $ExpectType Promise<void>
 
 wd.saveScreenshot(); // $ExpectError
-wd.saveScreenshot(str); // $ExpectType void
-wd.saveScreenshot(str, true); // $ExpectType void
+wd.saveScreenshot(str); // $ExpectType Promise<void>
+wd.saveScreenshot(str, true); // $ExpectType Promise<void>
 
 wd.setCookie(); // $ExpectError
-wd.setCookie({ name: str, value: str }); // $ExpectType void
-wd.setCookie([{ name: str, value: str }]); // $ExpectType void
+wd.setCookie({ name: str, value: str }); // $ExpectType Promise<void>
+wd.setCookie([{ name: str, value: str }]); // $ExpectType Promise<void>
 
-wd.clearCookie(); // $ExpectType void
-wd.clearCookie(str); // $ExpectType void
+wd.clearCookie(); // $ExpectType Promise<void>
+wd.clearCookie(str); // $ExpectType Promise<void>
 
 wd.seeCookie(); // $ExpectError
-wd.seeCookie(str); // $ExpectType void
+wd.seeCookie(str); // $ExpectType Promise<void>
 
 wd.acceptPopup(); // $ExpectType void
 
@@ -248,116 +248,116 @@ wd.seeInPopup(); // $ExpectError
 wd.seeInPopup(str); // $ExpectType void
 
 wd.pressKeyDown(); // $ExpectError
-wd.pressKeyDown(str); // $ExpectType void
+wd.pressKeyDown(str); // $ExpectType Promise<void>
 
 wd.pressKeyUp(); // $ExpectError
-wd.pressKeyUp(str); // $ExpectType void
+wd.pressKeyUp(str); // $ExpectType Promise<void>
 
 wd.pressKey(); // $ExpectError
-wd.pressKey(str); // $ExpectType void
+wd.pressKey(str); // $ExpectType Promise<void>
 
 wd.type(); // $ExpectError
-wd.type(str); // $ExpectType void
+wd.type(str); // $ExpectType Promise<void>
 
 wd.resizeWindow(); // $ExpectError
 wd.resizeWindow(num); // $ExpectError
-wd.resizeWindow(num, num); // $ExpectType void
+wd.resizeWindow(num, num); // $ExpectType Promise<void>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('div'); // $ExpectError
-wd.dragAndDrop('div', 'div'); // $ExpectType void
+wd.dragAndDrop('div', 'div'); // $ExpectType Promise<void>
 
 wd.dragSlider(); // $ExpectError
-wd.dragSlider('div', num); // $ExpectType void
+wd.dragSlider('div', num); // $ExpectType Promise<void>
 
 wd.switchToWindow(); // $ExpectError
 wd.switchToWindow(str); // $ExpectType void
 
-wd.closeOtherTabs(); // $ExpectType void
+wd.closeOtherTabs(); // $ExpectType Promise<void>
 
 wd.wait(); // $ExpectError
-wd.wait(num); // $ExpectType void
+wd.wait(num); // $ExpectType Promise<void>
 
 wd.waitForEnabled(); // $ExpectError
-wd.waitForEnabled('div'); // $ExpectType void
-wd.waitForEnabled('div', num); // $ExpectType void
+wd.waitForEnabled('div'); // $ExpectType Promise<void>
+wd.waitForEnabled('div', num); // $ExpectType Promise<void>
 
 wd.waitForElement(); // $ExpectError
-wd.waitForElement('div'); // $ExpectType void
-wd.waitForElement('div', num); // $ExpectType void
+wd.waitForElement('div'); // $ExpectType Promise<void>
+wd.waitForElement('div', num); // $ExpectType Promise<void>
 
 wd.waitForClickable(); // $ExpectError
-wd.waitForClickable('div'); // $ExpectType void
-wd.waitForClickable('div', num); // $ExpectType void
+wd.waitForClickable('div'); // $ExpectType Promise<void>
+wd.waitForClickable('div', num); // $ExpectType Promise<void>
 
 wd.waitForVisible(); // $ExpectError
-wd.waitForVisible('div'); // $ExpectType void
-wd.waitForVisible('div', num); // $ExpectType void
+wd.waitForVisible('div'); // $ExpectType Promise<void>
+wd.waitForVisible('div', num); // $ExpectType Promise<void>
 
 wd.waitForInvisible(); // $ExpectError
-wd.waitForInvisible('div'); // $ExpectType void
-wd.waitForInvisible('div', num); // $ExpectType void
+wd.waitForInvisible('div'); // $ExpectType Promise<void>
+wd.waitForInvisible('div', num); // $ExpectType Promise<void>
 
 wd.waitToHide(); // $ExpectError
-wd.waitToHide('div'); // $ExpectType void
-wd.waitToHide('div', num); // $ExpectType void
+wd.waitToHide('div'); // $ExpectType Promise<void>
+wd.waitToHide('div', num); // $ExpectType Promise<void>
 
 wd.waitForDetached(); // $ExpectError
-wd.waitForDetached('div'); // $ExpectType void
-wd.waitForDetached('div', num); // $ExpectType void
+wd.waitForDetached('div'); // $ExpectType Promise<void>
+wd.waitForDetached('div', num); // $ExpectType Promise<void>
 
 wd.waitForFunction(); // $ExpectError
-wd.waitForFunction('div'); // $ExpectType void
-wd.waitForFunction(() => {}); // $ExpectType void
-wd.waitForFunction(() => {}, [num], num); // $ExpectType void
-wd.waitForFunction(() => {}, [str], num); // $ExpectType void
+wd.waitForFunction('div'); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}, [num], num); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}, [str], num); // $ExpectType Promise<void>
 
 wd.waitInUrl(); // $ExpectError
-wd.waitInUrl(str); // $ExpectType void
-wd.waitInUrl(str, num); // $ExpectType void
+wd.waitInUrl(str); // $ExpectType Promise<void>
+wd.waitInUrl(str, num); // $ExpectType Promise<void>
 
 wd.waitForText(); // $ExpectError
-wd.waitForText(str); // $ExpectType void
-wd.waitForText(str, num, str); // $ExpectType void
+wd.waitForText(str); // $ExpectType Promise<void>
+wd.waitForText(str, num, str); // $ExpectType Promise<void>
 
 wd.waitForValue(); // $ExpectError
 wd.waitForValue(str); // $ExpectError
-wd.waitForValue(str, str); // $ExpectType void
-wd.waitForValue(str, str, num); // $ExpectType void
+wd.waitForValue(str, str); // $ExpectType Promise<void>
+wd.waitForValue(str, str, num); // $ExpectType Promise<void>
 
 wd.waitNumberOfVisibleElements(); // $ExpectError
 wd.waitNumberOfVisibleElements('div'); // $ExpectError
-wd.waitNumberOfVisibleElements(str, num); // $ExpectType void
-wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType void
+wd.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType Promise<void>
 
 wd.waitUrlEquals(); // $ExpectError
-wd.waitUrlEquals(str); // $ExpectType void
-wd.waitUrlEquals(str, num); // $ExpectType void
+wd.waitUrlEquals(str); // $ExpectType Promise<void>
+wd.waitUrlEquals(str, num); // $ExpectType Promise<void>
 
-wd.switchTo(); // $ExpectType void
-wd.switchTo('div'); // $ExpectType void
+wd.switchTo(); // $ExpectType Promise<void>
+wd.switchTo('div'); // $ExpectType Promise<void>
 
-wd.switchToNextTab(num, num); // $ExpectType void
+wd.switchToNextTab(num, num); // $ExpectType Promise<void>
 
-wd.switchToPreviousTab(num, num); // $ExpectType void
+wd.switchToPreviousTab(num, num); // $ExpectType Promise<void>
 
-wd.closeCurrentTab(); // $ExpectType void
+wd.closeCurrentTab(); // $ExpectType Promise<void>
 
-wd.openNewTab(); // $ExpectType void
+wd.openNewTab(); // $ExpectType Promise<void>
 
-wd.refreshPage(); // $ExpectType void
+wd.refreshPage(); // $ExpectType Promise<void>
 
-wd.scrollPageToTop(); // $ExpectType void
+wd.scrollPageToTop(); // $ExpectType Promise<void>
 
-wd.scrollPageToBottom(); // $ExpectType void
+wd.scrollPageToBottom(); // $ExpectType Promise<void>
 
 wd.setGeoLocation(); // $ExpectError
 wd.setGeoLocation(num); // $ExpectError
-wd.setGeoLocation(num, num); // $ExpectType void
-wd.setGeoLocation(num, num, num); // $ExpectType void
+wd.setGeoLocation(num, num); // $ExpectType Promise<void>
+wd.setGeoLocation(num, num, num); // $ExpectType Promise<void>
 
 wd.dontSeeCookie(); // $ExpectError
-wd.dontSeeCookie(str); // $ExpectType void
+wd.dontSeeCookie(str); // $ExpectType Promise<void>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('#dragHandle'); // $ExpectError


### PR DESCRIPTION
## Motivation/Description of the PR
- In TypeScript decision to await or ignore Promise<void> return types could be left to all end user projects' settings of lint rules https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md
While for those projects which want to benefit from clear typing and better debugging experience declaration require to have Promise<void> entries as that is the actual type returned by Actor object for corresponding void helper methods.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
